### PR TITLE
[BE] docs: Exam API 문서를 제공한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ plugins {
 	id 'org.springframework.boot' version '3.2.2'
 	id 'io.spring.dependency-management' version '1.1.4'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+
+	//OpenAPI
+	id 'com.epages.restdocs-api-spec' version '0.19.1'
 }
 
 group = 'capstone'
@@ -43,19 +46,16 @@ dependencies {
 
 	//Elastic Search
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
+	//OpenAPI
+	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.1'
 }
 
 tasks.named('test') {
-	outputs.dir snippetsDir
 	useJUnitPlatform(){
 		includeTags 'basic_test'
 		excludeTags 'db_test'
 	}
-}
-
-tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	dependsOn test
 }
 
 task basicTest(type:Test) {
@@ -68,4 +68,21 @@ task dbTest(type: Test) {
 	useJUnitPlatform {
 		includeTags 'db_test'
 	}
+}
+
+task copyOasToStatic(type: Copy) {
+	dependsOn 'openapi3'
+	doFirst {
+		delete 'src/main/resources/static/api/v1/openapi3.yaml'
+	}
+	from 'build/api-spec/openapi3.yaml'
+	into 'src/main/resources/static/api/v1'
+}
+
+openapi3 {
+	server = 'http://localhost:8080'
+	title = 'Exam Lab API'
+	description = 'API for Exam Lab'
+	version = '0.1.0'
+	format = 'yaml'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,88 +1,95 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.2'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 
-	//OpenAPI
-	id 'com.epages.restdocs-api-spec' version '0.19.1'
+    //OpenAPI
+    id 'com.epages.restdocs-api-spec' version '0.19.1'
 }
 
 group = 'capstone'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('snippetsDir', file("build/generated-snippets"))
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-	//Validation
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    //Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	//H2 DB
-	runtimeOnly 'com.h2database:h2'
+    //H2 DB
+    runtimeOnly 'com.h2database:h2'
 
-	//Elastic Search
-	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    //Elastic Search
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
-	//OpenAPI
-	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.1'
+    //OpenAPI
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.1'
 }
 
 tasks.named('test') {
-	useJUnitPlatform(){
-		includeTags 'basic_test'
-		excludeTags 'db_test'
-	}
+    useJUnitPlatform() {
+        includeTags 'basic_test'
+        includeTags 'openapi_test'
+        excludeTags 'db_test'
+    }
 }
 
-task basicTest(type:Test) {
-	useJUnitPlatform {
-		includeTags 'basic_test'
-	}
+task basicTest(type: Test) {
+    useJUnitPlatform {
+        includeTags 'basic_test'
+    }
 }
 
 task dbTest(type: Test) {
-	useJUnitPlatform {
-		includeTags 'db_test'
-	}
+    useJUnitPlatform {
+        includeTags 'db_test'
+    }
+}
+
+task openApiTest(type: Test) {
+    useJUnitPlatform {
+        includeTags 'openapi_test'
+    }
 }
 
 task copyOasToStatic(type: Copy) {
-	dependsOn 'openapi3'
-	doFirst {
-		delete 'src/main/resources/static/api/v1/openapi3.yaml'
-	}
-	from 'build/api-spec/openapi3.yaml'
-	into 'src/main/resources/static/api/v1'
+    dependsOn 'openapi3'
+    doFirst {
+        delete 'src/main/resources/static/api/v1/openapi3.yaml'
+    }
+    from 'build/api-spec/openapi3.yaml'
+    into 'src/main/resources/static/api/v1'
 }
 
 openapi3 {
-	server = 'http://localhost:8080'
-	title = 'Exam Lab API'
-	description = 'API for Exam Lab'
-	version = '0.1.0'
-	format = 'yaml'
+    servers = [{ url = 'http://exam-lab.store/' }, { url = 'http://localhost:8080/' }]
+    title = 'Exam Lab API'
+    description = 'API for Exam Lab'
+    version = '0.1.0'
+    format = 'yaml'
 }

--- a/src/main/java/capstone/examlab/ExamLabApplication.java
+++ b/src/main/java/capstone/examlab/ExamLabApplication.java
@@ -2,6 +2,8 @@ package capstone.examlab;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @SpringBootApplication
 public class ExamLabApplication {
@@ -10,4 +12,12 @@ public class ExamLabApplication {
 		SpringApplication.run(ExamLabApplication.class, args);
 	}
 
+	@Controller
+	public static class WelcomeController {
+
+		@GetMapping("/api/v1/")
+		public String redirectToIndexHtml() {
+			return "forward:/api/v1/index.html";
+		}
+	}
 }

--- a/src/main/java/capstone/examlab/exams/dto/ExamDetail.java
+++ b/src/main/java/capstone/examlab/exams/dto/ExamDetail.java
@@ -4,13 +4,11 @@ package capstone.examlab.exams.dto;
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Data
 @Builder
-
 public class ExamDetail {
     private String examTitle;
-    private List<SubExamDetail> subExams = new ArrayList<>();
+    private List<SubExamDetail> subExams;
 }

--- a/src/main/java/capstone/examlab/exams/dto/ExamType.java
+++ b/src/main/java/capstone/examlab/exams/dto/ExamType.java
@@ -4,6 +4,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ExamType extends HashMap<String, Object> {
+    public ExamType(int initialCapacity, float loadFactor) {
+        super(initialCapacity, loadFactor);
+    }
+
+    public ExamType(int initialCapacity) {
+        super(initialCapacity);
+    }
+
+    public ExamType() {
+    }
+
     public ExamType(Map<? extends String, ?> m) {
         super(m);
     }

--- a/src/main/resources/static/api/v1/index.html
+++ b/src/main/resources/static/api/v1/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="SwaggerUI" />
+    <title>SwaggerUI</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+<script>
+    window.onload = () => {
+        window.ui = SwaggerUIBundle({
+            url: 'openapi3.yaml',
+            dom_id: '#swagger-ui',
+        });
+    };
+</script>
+</body>
+</html>

--- a/src/main/resources/static/api/v1/openapi3.yaml
+++ b/src/main/resources/static/api/v1/openapi3.yaml
@@ -1,0 +1,101 @@
+openapi: 3.0.1
+info:
+  title: Exam Lab API
+  description: API for Exam Lab
+  version: 0.1.0
+servers:
+- url: http://exam-lab.store/
+- url: http://localhost:8080/
+tags: []
+paths:
+  /api/v1/exams:
+    get:
+      tags:
+      - exams
+      summary: Get all exams
+      description: Get all exams
+      operationId: exams
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExamList'
+              examples:
+                exams:
+                  value: "[{\"exam_title\":\"운전면허\",\"sub_exams\":[{\"exam_id\":1,\"\
+                    sub_title\":\"1종, 2종\"}]}]"
+  /api/v1/exams/{examId}/type:
+    get:
+      tags:
+      - exams
+      summary: Get exam type
+      description: Get exam type
+      operationId: exam-typenon-exam-type
+      parameters:
+      - name: examId
+        in: path
+        description: Exam id
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExamType'
+              examples:
+                exam-type:
+                  value: "{\"tags\":[\"상황\",\"표지\",\"화물\",\"법\"]}"
+        "400":
+          description: "400"
+components:
+  schemas:
+    ExamList:
+      title: ExamList
+      type: array
+      description: List of exams
+      items:
+        required:
+        - exam_title
+        - sub_exams
+        type: object
+        properties:
+          sub_exams:
+            type: array
+            description: List of sub exams
+            items:
+              required:
+              - exam_id
+              - sub_title
+              type: object
+              properties:
+                sub_title:
+                  type: string
+                  description: Sub exam title
+                exam_id:
+                  type: number
+                  description: Sub exam id
+          exam_title:
+            type: string
+            description: Exam title
+        description: List of exams
+    ExamType:
+      title: ExamType
+      required:
+      - tags
+      type: object
+      properties:
+        tags:
+          type: array
+          description: List of tags
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number

--- a/src/test/java/capstone/examlab/RestDocsOpenApiSpecTest.java
+++ b/src/test/java/capstone/examlab/RestDocsOpenApiSpecTest.java
@@ -1,0 +1,25 @@
+package capstone.examlab;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+@ExtendWith({RestDocumentationExtension.class})
+public abstract class RestDocsOpenApiSpecTest {
+
+    protected MockMvc mockMvc;
+
+    @BeforeEach
+    void setUpMockMvc(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
+}

--- a/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
+++ b/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
@@ -1,0 +1,111 @@
+package capstone.examlab.exams.controller;
+
+import capstone.examlab.RestDocsOpenApiSpecTest;
+import capstone.examlab.exams.dto.*;
+import capstone.examlab.exams.repository.ExamRepository;
+import capstone.examlab.exams.service.ExamsService;
+import capstone.examlab.questions.dto.QuestionsList;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.epages.restdocs.apispec.SimpleType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+//@WebMvcTest(ExamsController.class)
+@SpringBootTest
+@Tag("openapi_test")
+class ExamControllerOasTest extends RestDocsOpenApiSpecTest {
+
+    private final Long existExamId = 1L;
+    private final Long notExamId = 0L;
+
+    @BeforeEach
+    public void beforeTest() {
+
+    }
+
+    @Test
+    void getExams() throws Exception {
+        this.mockMvc.perform(
+                        get("/api/v1/exams")
+                )
+                .andExpect(status().isOk())
+                .andDo(document("exams",
+                        resource(ResourceSnippetParameters.builder()
+                                .description("Get all exams")
+                                .tag("exams")
+                                .summary("Get all exams")
+                                .responseFields(
+                                        fieldWithPath("[]").description("List of exams").type(JsonFieldType.ARRAY),
+                                        subsectionWithPath("[].exam_title").description("Exam title").type(JsonFieldType.STRING),
+                                        fieldWithPath("[].sub_exams").description("List of sub exams"),
+                                        fieldWithPath("[].sub_exams[].exam_id").description("Sub exam id").type(JsonFieldType.NUMBER),
+                                        fieldWithPath("[].sub_exams[].sub_title").description("Sub exam title").type(JsonFieldType.STRING)
+                                )
+                                .responseSchema(Schema.schema("ExamList"))
+                                .build()
+                        )
+                ));
+    }
+
+    @Test
+    void testGetExamType() throws Exception {
+
+        this.mockMvc.perform(get("/api/v1/exams/{examId}/type", existExamId))
+                .andExpect(status().isOk())
+                .andDo(document("exam-type",
+                        resource(ResourceSnippetParameters.builder()
+                                .description("Get exam type")
+                                .tag("exams")
+                                .summary("Get exam type")
+                                .pathParameters(
+                                        parameterWithName("examId").description("Exam id").type(SimpleType.INTEGER)
+                                )
+                                .responseFields(
+                                        fieldWithPath("tags").description("List of tags").type(JsonFieldType.ARRAY)
+                                )
+                                .responseSchema(Schema.schema("ExamType"))
+                                .build()
+                        )
+                ));
+    }
+
+    @Test
+    void testGetNotExamType() throws Exception {
+
+        this.mockMvc.perform(get("/api/v1/exams/{examId}/type", notExamId))
+                .andExpect(status().isBadRequest())
+                .andDo(document("non-exam-type",
+                        resource(ResourceSnippetParameters.builder()
+                                .description("Get non exam type")
+                                .tag("exams")
+                                .summary("Get non exam type")
+                                .pathParameters(
+                                        parameterWithName("examId").description("Non Exam id").type(SimpleType.INTEGER)
+                                )
+                                .build()
+                        )
+                ));
+    }
+}


### PR DESCRIPTION
## 변경사항
- Swagger 생성을 위한 테스트 태그 추가
- Swagger 셍성을 위한 의존성 추가
  - 배경의 블로그 글 참조

## 배경
- [테스트코드로 Swagger 생성하기](https://code-l.tistory.com/36)
- 사라진 테스트 문서를 제공하여 프론트의 개발 편의성을 제공합니다

## 테스트 방법
- http://localhost:8080/api/v1/ 접속시 스웨거를 확인할 수 있습니다
- 테스트 할 서버를 선택할 수 있습니다
![image](https://github.com/LuizyHub/Exam-Lab/assets/104267255/baf500c5-4f21-4fc6-9352-f3f9147b67df)
- 테스트를 돌려 볼 수 있습니다
```bash
./gradlew openApiTest
```

## 궁금한점
- 없습니다

close #35 