### PR TITLE
[BE] Feature: Question Add, Update, Delete 검증 추가 

### DIFF
--- a/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
+++ b/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
@@ -102,4 +102,11 @@ public class ExamServiceImpl implements ExamsService {
 
         examRepository.save(exam);
     }
+
+    @Override
+    public boolean isExamOwner(Long examId, User user) {
+        Exam exam = (Exam) examRepository.findByExamId(examId).get();
+        if(exam.getUser() == null) return false;
+        return exam.getUser().getUserId().equals(user.getUserId());
+    }
 }

--- a/src/main/java/capstone/examlab/exams/service/ExamsService.java
+++ b/src/main/java/capstone/examlab/exams/service/ExamsService.java
@@ -19,4 +19,6 @@ public interface ExamsService {
     public void deleteExam(Long id, User user);
 
     public void updateExam(Long id, ExamUpdateDto examUpdateDto, User user);
+
+    public boolean isExamOwner(Long examId, User user);
 }

--- a/src/main/java/capstone/examlab/questions/controller/QuestionsController.java
+++ b/src/main/java/capstone/examlab/questions/controller/QuestionsController.java
@@ -36,9 +36,8 @@ public class QuestionsController {
     @PostMapping("/exams/{examId}/questions")
     public ResponseDto addQuestionsByExamId(@PathVariable @ValidExamId Long examId, @RequestPart QuestionUploadInfo questionUploadInfo, @RequestPart(name = "questionImagesIn", required = false) List<MultipartFile> questionImagesIn,
                                             @RequestPart(name = "questionImagesOut", required = false) List<MultipartFile> questionImagesOut, @RequestPart(name = "commentaryImagesIn", required = false) List<MultipartFile> commentaryImagesIn,
-                                            @RequestPart(name = "commentaryImagesOut", required = false) List<MultipartFile> commentaryImagesOut) {
-
-        String questionId = questionsService.addQuestionsByExamId(examId, questionUploadInfo, questionImagesIn, questionImagesOut, commentaryImagesIn, commentaryImagesOut);
+                                            @RequestPart(name = "commentaryImagesOut", required = false) List<MultipartFile> commentaryImagesOut, @Login User user) {
+        String questionId = questionsService.addQuestionsByExamId(user, examId, questionUploadInfo, questionImagesIn, questionImagesOut, commentaryImagesIn, commentaryImagesOut);
         if (questionId == null) {
             return ResponseDto.BAD_REQUEST;
         }
@@ -100,7 +99,7 @@ public class QuestionsController {
 
     //Delete API with examId
     @DeleteMapping("/exams/{examId}/questions")
-    public ResponseDto deleteQuestionsByExamId(@PathVariable @ValidExamId Long examId, HttpServletResponse response) {
+    public ResponseDto deleteQuestionsByExamId(@PathVariable @ValidExamId Long examId) {
         boolean deleted = questionsService.deleteQuestionsByExamId(examId);
         if (!deleted) {
             return ResponseDto.BAD_REQUEST;
@@ -110,7 +109,7 @@ public class QuestionsController {
 
     //Delete Api with questionId
     @DeleteMapping("/questions/{questionId}")
-    public ResponseDto deleteQuestionsByQuestionId(@PathVariable String questionId, HttpServletResponse response) {
+    public ResponseDto deleteQuestionsByQuestionId(@PathVariable String questionId) {
         boolean deleted = questionsService.deleteQuestionsByQuestionId(questionId);
         if(!deleted) {
             return ResponseDto.BAD_REQUEST;

--- a/src/main/java/capstone/examlab/questions/controller/QuestionsController.java
+++ b/src/main/java/capstone/examlab/questions/controller/QuestionsController.java
@@ -7,6 +7,8 @@ import capstone.examlab.questions.dto.search.QuestionsSearchDto;
 import capstone.examlab.questions.dto.update.QuestionUpdateDto;
 import capstone.examlab.questions.dto.upload.QuestionUploadInfo;
 import capstone.examlab.questions.service.QuestionsService;
+import capstone.examlab.users.argumentresolver.Login;
+import capstone.examlab.users.domain.User;
 import capstone.examlab.valid.ValidExamId;
 import capstone.examlab.valid.ValidParams;
 import jakarta.servlet.http.HttpServletResponse;
@@ -88,8 +90,8 @@ public class QuestionsController {
 
     //Update API
     @PutMapping("/questions")
-    public ResponseDto updateQuestions(@RequestBody QuestionUpdateDto questionUpdateDto) {
-        boolean updated = questionsService.updateQuestionsByQuestionId(questionUpdateDto);
+    public ResponseDto updateQuestions(@Login User user, @RequestBody QuestionUpdateDto questionUpdateDto) {
+        boolean updated = questionsService.updateQuestionsByQuestionId(user, questionUpdateDto);
         if (!updated) {
             return ResponseDto.BAD_REQUEST;
         }

--- a/src/main/java/capstone/examlab/questions/controller/QuestionsController.java
+++ b/src/main/java/capstone/examlab/questions/controller/QuestionsController.java
@@ -11,10 +11,8 @@ import capstone.examlab.users.argumentresolver.Login;
 import capstone.examlab.users.domain.User;
 import capstone.examlab.valid.ValidExamId;
 import capstone.examlab.valid.ValidParams;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -109,8 +107,8 @@ public class QuestionsController {
 
     //Delete Api with questionId
     @DeleteMapping("/questions/{questionId}")
-    public ResponseDto deleteQuestionsByQuestionId(@PathVariable String questionId) {
-        boolean deleted = questionsService.deleteQuestionsByQuestionId(questionId);
+    public ResponseDto deleteQuestionsByQuestionId(@Login User user, @PathVariable String questionId) {
+        boolean deleted = questionsService.deleteQuestionsByQuestionId(user, questionId);
         if(!deleted) {
             return ResponseDto.BAD_REQUEST;
         }

--- a/src/main/java/capstone/examlab/questions/dto/upload/QuestionUploadInfo.java
+++ b/src/main/java/capstone/examlab/questions/dto/upload/QuestionUploadInfo.java
@@ -4,7 +4,6 @@ import capstone.examlab.questions.dto.ImageDto;
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/capstone/examlab/questions/dto/upload/QuestionUploadInfo.java
+++ b/src/main/java/capstone/examlab/questions/dto/upload/QuestionUploadInfo.java
@@ -4,6 +4,7 @@ import capstone.examlab.questions.dto.ImageDto;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/capstone/examlab/questions/service/QuestionsService.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsService.java
@@ -4,6 +4,7 @@ import capstone.examlab.questions.dto.QuestionsListDto;
 import capstone.examlab.questions.dto.search.QuestionsSearchDto;
 import capstone.examlab.questions.dto.update.QuestionUpdateDto;
 import capstone.examlab.questions.dto.upload.QuestionUploadInfo;
+import capstone.examlab.users.domain.User;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -14,7 +15,7 @@ public interface QuestionsService {
 
     QuestionsListDto searchFromQuestions(Long examId, QuestionsSearchDto questionsSearchDto);
 
-    boolean updateQuestionsByQuestionId(QuestionUpdateDto questionsUpdateDto);
+    boolean updateQuestionsByQuestionId(User user, QuestionUpdateDto questionsUpdateDto);
 
     boolean deleteQuestionsByExamId(Long examId);
 

--- a/src/main/java/capstone/examlab/questions/service/QuestionsService.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsService.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 
 public interface QuestionsService {
-    String addQuestionsByExamId(Long examId, QuestionUploadInfo questionUploadInfo, List<MultipartFile> questionImagesIn, List<MultipartFile> questionImagesOut, List<MultipartFile> commentaryImagesIn, List<MultipartFile> commentaryImagesOut );
+    String addQuestionsByExamId(User user, Long examId, QuestionUploadInfo questionUploadInfo, List<MultipartFile> questionImagesIn, List<MultipartFile> questionImagesOut, List<MultipartFile> commentaryImagesIn, List<MultipartFile> commentaryImagesOut );
 
     QuestionsListDto searchFromQuestions(Long examId, QuestionsSearchDto questionsSearchDto);
 

--- a/src/main/java/capstone/examlab/questions/service/QuestionsService.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsService.java
@@ -19,5 +19,5 @@ public interface QuestionsService {
 
     boolean deleteQuestionsByExamId(Long examId);
 
-    boolean deleteQuestionsByQuestionId(String questionId);
+    boolean deleteQuestionsByQuestionId(User user, String questionId);
 }

--- a/src/main/java/capstone/examlab/questions/service/QuestionsServiceImpl.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsServiceImpl.java
@@ -36,8 +36,12 @@ public class QuestionsServiceImpl implements QuestionsService {
 
     //Create 로직
     @Override
-    public String addQuestionsByExamId(Long examId, QuestionUploadInfo questionUploadInfo, List<MultipartFile> questionImagesIn, List<MultipartFile> questionImagesOut, List<MultipartFile> commentaryImagesIn, List<MultipartFile> commentaryImagesOut) {
-        log.info(questionUploadInfo.toString());
+    public String addQuestionsByExamId(User user, Long examId, QuestionUploadInfo questionUploadInfo, List<MultipartFile> questionImagesIn, List<MultipartFile> questionImagesOut, List<MultipartFile> commentaryImagesIn, List<MultipartFile> commentaryImagesOut) {
+        //문제 생성 권한이 있는 유저 체크
+        if(!examsService.isExamOwner(examId,user)){
+            throw new UnauthorizedException();
+        }
+
         if (questionImagesIn != null) {
             for (int i = 0; i < questionImagesIn.size(); i++) {
                 String imageUrl = imageService.saveImageInS3(questionImagesIn.get(i));
@@ -126,6 +130,7 @@ public class QuestionsServiceImpl implements QuestionsService {
         Optional<QuestionEntity> optionalQuestion = questionsRepository.findById(questionUpdateDto.getId());
         if (optionalQuestion.isPresent()) {
             QuestionEntity question = optionalQuestion.get();
+            //문제 수정 권한이 있는 유저 체크
             if(!examsService.isExamOwner(question.getExamId(),user)){
                 throw new UnauthorizedException();
             }

--- a/src/main/resources/static/api/v1/openapi3.yaml
+++ b/src/main/resources/static/api/v1/openapi3.yaml
@@ -66,18 +66,20 @@ paths:
             examples:
               update-question:
                 value: "{\"question\":\"변경된 질문입니다.\",\"options\":[\"변경된 보기1\",\"변경\
-                  된 보기2\",\"변경된 보기3\",\"변경된 보기4\"],\"answers\":[1,3],\"id\":\"f7cc865e-f5b0-4974-9f3d-a86d782b1cb5\"\
-                  ,\"tag\":{\"category\":[\"상황\"]},\"commentary\":\"변경된 설명입니다.\"}"
+                  된 보기2\",\"변경된 보기3\",\"변경된 보기4\"],\"answers\":[1,3],\"id\":\"{\\\"\
+                  code\\\":201,\\\"message\\\":\\\"2fbcbc5d-1556-48c8-9fca-383d82417272\\\
+                  \"}\",\"tag\":{\"난이도\":[\"중\"],\"단원\":[\"2\"]},\"commentary\":\"\
+                  변경된 설명입니다.\"}"
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-questions486549215'
               examples:
                 update-question:
-                  value: "{\"code\":200,\"message\":\"OK\"}"
+                  value: "{\"code\":400,\"message\":\"BAD_REQUEST\"}"
   /api/v1/users:
     post:
       tags:
@@ -92,10 +94,10 @@ paths:
               $ref: '#/components/schemas/api-v1-users-963924044'
             examples:
               user add:
-                value: "{\"password\":\"7e8d62eb-309d-4c1d-a14b-0b8c61c52913!\",\"\
-                  password_confirm\":\"7e8d62eb-309d-4c1d-a14b-0b8c61c52913!\",\"\
-                  user_id\":\"7e8d62eb-309d-4c1d-a14b-0b8c61c52913@gmail.com\",\"\
-                  name\":\"7e8d62eb-309d-4c1d-a14b-0b8c61c52913\"}"
+                value: "{\"password\":\"6bfa9ac7-b3c9-4d25-b32c-9f6a78a48cda!\",\"\
+                  password_confirm\":\"6bfa9ac7-b3c9-4d25-b32c-9f6a78a48cda!\",\"\
+                  user_id\":\"6bfa9ac7-b3c9-4d25-b32c-9f6a78a48cda@gmail.com\",\"\
+                  name\":\"6bfa9ac7-b3c9-4d25-b32c-9f6a78a48cda\"}"
       responses:
         "200":
           description: "200"
@@ -145,7 +147,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-exams-examId486549215'
+              $ref: '#/components/schemas/api-v1-exams-examId-questions486549215'
             examples:
               patch-exams:
                 value: "{\"tags\":{\"난이도\":[\"상\",\"중\",\"하\",\"최하\"],\"단원\":[\"1\"\
@@ -156,7 +158,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-questions486549215'
               examples:
                 patch-exams:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -196,10 +198,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-questions486549215'
               examples:
                 delete-questions-by-questionId:
-                  value: "{\"code\":200,\"message\":\"OK\"}"
+                  value: "{\"code\":400,\"message\":\"BAD_REQUEST\"}"
   /api/v1/users/login:
     post:
       tags:
@@ -334,10 +336,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-questions486549215'
               examples:
                 add-questions:
-                  value: "{\"code\":201,\"message\":\"3ecbe193-580e-4c8a-b40a-4850e756938e\"\
+                  value: "{\"code\":201,\"message\":\"dcac4a4e-1df0-4f27-a70c-68493e16cf4a\"\
                     }"
 components:
   schemas:
@@ -584,7 +586,7 @@ components:
         login:
           type: boolean
           description: 로그인 여부
-    api-v1-exams-examId486549215:
+    api-v1-exams-examId-questions486549215:
       type: object
     api-v1-users-963924044:
       required:

--- a/src/main/resources/static/api/v1/openapi3.yaml
+++ b/src/main/resources/static/api/v1/openapi3.yaml
@@ -62,24 +62,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-questions-1819950696'
+              $ref: '#/components/schemas/api-v1-questions-420259584'
             examples:
               update-question:
                 value: "{\"question\":\"변경된 질문입니다.\",\"options\":[\"변경된 보기1\",\"변경\
-                  된 보기2\",\"변경된 보기3\",\"변경된 보기4\"],\"answers\":[1,3],\"id\":\"{\\\"\
-                  code\\\":201,\\\"message\\\":\\\"2fbcbc5d-1556-48c8-9fca-383d82417272\\\
-                  \"}\",\"tag\":{\"난이도\":[\"중\"],\"단원\":[\"2\"]},\"commentary\":\"\
-                  변경된 설명입니다.\"}"
+                  된 보기2\",\"변경된 보기3\",\"변경된 보기4\"],\"answers\":[1,3],\"id\":\"88f85e8d-f59b-4e39-a5a1-fed0006e467c\"\
+                  ,\"commentary\":\"변경된 설명입니다.\",\"tags\":{\"난이도\":[\"중\"],\"단원\"\
+                  :[\"2\"]}}"
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId486549215'
               examples:
                 update-question:
-                  value: "{\"code\":400,\"message\":\"BAD_REQUEST\"}"
+                  value: "{\"code\":200,\"message\":\"OK\"}"
   /api/v1/users:
     post:
       tags:
@@ -94,10 +93,10 @@ paths:
               $ref: '#/components/schemas/api-v1-users-963924044'
             examples:
               user add:
-                value: "{\"password\":\"6bfa9ac7-b3c9-4d25-b32c-9f6a78a48cda!\",\"\
-                  password_confirm\":\"6bfa9ac7-b3c9-4d25-b32c-9f6a78a48cda!\",\"\
-                  user_id\":\"6bfa9ac7-b3c9-4d25-b32c-9f6a78a48cda@gmail.com\",\"\
-                  name\":\"6bfa9ac7-b3c9-4d25-b32c-9f6a78a48cda\"}"
+                value: "{\"password\":\"86826d6b-69f7-4e60-aa02-1edf9d703d4b!\",\"\
+                  password_confirm\":\"86826d6b-69f7-4e60-aa02-1edf9d703d4b!\",\"\
+                  user_id\":\"86826d6b-69f7-4e60-aa02-1edf9d703d4b@gmail.com\",\"\
+                  name\":\"86826d6b-69f7-4e60-aa02-1edf9d703d4b\"}"
       responses:
         "200":
           description: "200"
@@ -147,7 +146,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-exams-examId-questions486549215'
+              $ref: '#/components/schemas/api-v1-exams-examId486549215'
             examples:
               patch-exams:
                 value: "{\"tags\":{\"난이도\":[\"상\",\"중\",\"하\",\"최하\"],\"단원\":[\"1\"\
@@ -158,7 +157,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId486549215'
               examples:
                 patch-exams:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -198,10 +197,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId486549215'
               examples:
                 delete-questions-by-questionId:
-                  value: "{\"code\":400,\"message\":\"BAD_REQUEST\"}"
+                  value: "{\"code\":200,\"message\":\"OK\"}"
   /api/v1/users/login:
     post:
       tags:
@@ -263,9 +262,15 @@ paths:
         schema:
           type: integer
           format: int32
-      - name: tags_category
+      - name: tags_단원
         in: query
-        description: 문제의 태그 카테고리
+        description: 문제의 태그 - 단원
+        required: false
+        schema:
+          type: string
+      - name: tags_난이도
+        in: query
+        description: 문제의 태그 - 난이도
         required: false
         schema:
           type: string
@@ -288,23 +293,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-questions-1602847952'
+                $ref: '#/components/schemas/api-v1-exams-examId-questions-1876066633'
               examples:
                 Search-questions:
-                  value: "{\"questions\":[{\"id\":\"53611a95-24c2-4fc3-aad6-407391492f90\"\
-                    ,\"type\":\"객관식\",\"question\":\"고속도로를 주행 중이다. 가장 안전한 운전 방법 2가\
-                    지는?\",\"question_images_in\":[],\"question_images_out\":[{\"url\"\
-                    :\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/driver_images/744.png\"\
-                    ,\"description\":\"\",\"attribute\":\"examlab-image-right\"}],\"\
-                    options\":[\"① 우측 방향 지시등을 켜고 우측으로 차로 변경 후 앞지르기한다.\",\"② 앞서 가는\
-                    \ 화물차와의 안전거리를 좁히면서 운전한다.\",\"③ 앞차를 앞지르기 위해 좌측 방향 지시등을 켜고 전후방의\
-                    \ 안전을 살핀\\n후에 좌측으로 앞지르기한다.\",\"④ 앞서 가는 화물차와의 안전거리를 충분히 유지하면서 운\
-                    전한다.\",\"⑤ 경음기를 계속 울리며 빨리 가도록 재촉한다.\"],\"answers\":[3,4],\"commentary\"\
-                    :\"모든 차의 운전자는 다른 차를 앞지르고자 하는 때에는 앞차의 좌측으로 통행하여야 한다. 운전자는 차의 조향\
-                    장\\n치･제동장치와 그 밖의 장치를 정확하게 조작하여야 하며, 도로의 교통 상황과 차의 구조 및 성능에 따라\
-                    \ 다른 사\\n람에게 위험과 장해를 주는 속도나 방법으로 운전하여서는 아니 된다.\",\"commentary_images_in\"\
-                    :[],\"commentary_images_out\":[],\"tags\":{\"category\":[\"상황\"\
-                    ]}}],\"size\":1}"
+                  value: "{\"questions\":[{\"id\":\"a241111e-23b6-4c2f-911b-008a60294b5c\"\
+                    ,\"type\":\"객관식\",\"question\":\"소웨공 테스트 문제?\",\"question_images_in\"\
+                    :[],\"question_images_out\":[],\"options\":[\"① 답 예시 1\",\"② 답\
+                    \ 예시 2\",\"③ 답 예시 3\",\"④ 답 예시 4\"],\"answers\":[3],\"commentary\"\
+                    :\"30이 가장 큰 수입니다.\",\"commentary_images_in\":[],\"commentary_images_out\"\
+                    :[],\"tags\":{\"단원\":[\"1\"],\"난이도\":[\"하\"]}}],\"size\":1}"
     post:
       tags:
       - question
@@ -336,10 +333,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId486549215'
               examples:
                 add-questions:
-                  value: "{\"code\":201,\"message\":\"dcac4a4e-1df0-4f27-a70c-68493e16cf4a\"\
+                  value: "{\"code\":201,\"message\":\"7f71e7e5-96ab-4ad1-8fa7-fe1ec77d62e0\"\
                     }"
 components:
   schemas:
@@ -355,6 +352,57 @@ components:
         message:
           type: string
           description: 생성된 시험지 ID
+    api-v1-questions-420259584:
+      required:
+      - answers
+      - commentary
+      - id
+      - options
+      - question
+      - tags
+      type: object
+      properties:
+        question:
+          type: string
+          description: 변경될 질문 내용
+        answers:
+          type: array
+          description: 변경될 정답
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        options:
+          type: array
+          description: 변경될 보기 내용
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        id:
+          type: string
+          description: 문제 ID
+        commentary:
+          type: string
+          description: 변경될 해설
+        tags:
+          type: object
+          properties:
+            '*':
+              type: array
+              description: 변경될 문제 태그 value
+              nullable: true
+              items:
+                oneOf:
+                - type: object
+                - type: boolean
+                - type: string
+                - type: number
+          description: 변경될 문제 태그
     ExamType:
       title: ExamType
       type: object
@@ -391,7 +439,7 @@ components:
         user_id:
           type: string
           description: User id
-    api-v1-exams-examId-questions-1602847952:
+    api-v1-exams-examId-questions-1876066633:
       required:
       - questions
       - size
@@ -425,30 +473,38 @@ components:
                 type: array
                 description: 문제 정답 이미지 목록
                 items:
-                  required:
-                  - attribute
-                  - description
-                  - url
                   type: object
                   properties:
                     description:
                       type: string
                       description: 이미지 설명
+                      nullable: true
                     attribute:
                       type: string
                       description: 이미지 속성
+                      nullable: true
                     url:
                       type: string
                       description: 이미지 URL
+                      nullable: true
               question_images_in:
                 type: array
                 description: 문제 설명 이미지 목록
                 items:
-                  oneOf:
-                  - type: object
-                  - type: boolean
-                  - type: string
-                  - type: number
+                  type: object
+                  properties:
+                    description:
+                      type: string
+                      description: 이미지 설명
+                      nullable: true
+                    attribute:
+                      type: string
+                      description: 이미지 속성
+                      nullable: true
+                    url:
+                      type: string
+                      description: 이미지 URL
+                      nullable: true
               answers:
                 type: array
                 description: 정답 목록
@@ -477,31 +533,48 @@ components:
                 type: array
                 description: 해설 설명 이미지 목록
                 items:
-                  oneOf:
-                  - type: object
-                  - type: boolean
-                  - type: string
-                  - type: number
+                  type: object
+                  properties:
+                    description:
+                      type: string
+                      description: 이미지 설명
+                      nullable: true
+                    attribute:
+                      type: string
+                      description: 이미지 속성
+                      nullable: true
+                    url:
+                      type: string
+                      description: 이미지 URL
+                      nullable: true
               commentary_images_out:
                 type: array
                 description: 해설 이미지 목록
                 items:
-                  oneOf:
-                  - type: object
-                  - type: boolean
-                  - type: string
-                  - type: number
+                  type: object
+                  properties:
+                    description:
+                      type: string
+                      description: 이미지 설명
+                      nullable: true
+                    attribute:
+                      type: string
+                      description: 이미지 속성
+                      nullable: true
+                    url:
+                      type: string
+                      description: 이미지 URL
+                      nullable: true
               commentary:
                 type: string
                 description: 문제 해설
               tags:
-                required:
-                - '*'
                 type: object
                 properties:
                   '*':
                     type: array
                     description: 문제의 카테고리 태그 정보
+                    nullable: true
                     items:
                       oneOf:
                       - type: object
@@ -509,58 +582,6 @@ components:
                       - type: string
                       - type: number
                 description: 문제의 태그 맵 정보
-    api-v1-questions-1819950696:
-      required:
-      - answers
-      - commentary
-      - id
-      - options
-      - question
-      - tag
-      type: object
-      properties:
-        question:
-          type: string
-          description: 변경될 질문 내용
-        answers:
-          type: array
-          description: 변경될 정답
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
-        options:
-          type: array
-          description: 변경될 보기 내용
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
-        tag:
-          required:
-          - '*'
-          type: object
-          properties:
-            '*':
-              type: array
-              description: 변경될 문제 태그 value
-              items:
-                oneOf:
-                - type: object
-                - type: boolean
-                - type: string
-                - type: number
-          description: 변경될 문제 태그
-        id:
-          type: string
-          description: 문제 ID
-        commentary:
-          type: string
-          description: 변경될 해설
     ExamAdd:
       title: ExamAdd
       required:
@@ -586,7 +607,7 @@ components:
         login:
           type: boolean
           description: 로그인 여부
-    api-v1-exams-examId-questions486549215:
+    api-v1-exams-examId486549215:
       type: object
     api-v1-users-963924044:
       required:

--- a/src/test/java/capstone/examlab/questions/controller/QuestionsControllerOasTest.java
+++ b/src/test/java/capstone/examlab/questions/controller/QuestionsControllerOasTest.java
@@ -112,7 +112,6 @@ class QuestionsControllerOasTest extends RestDocsOpenApiSpecTest {
         String responseContent = result.getResponse().getContentAsString();
         JsonNode jsonResponse = objectMapper.readTree(responseContent);
         questionId = jsonResponse.get("message").asText();
-        System.out.println("데이터 삽입: " + questionId);
     }
 
     @AfterEach
@@ -184,7 +183,6 @@ class QuestionsControllerOasTest extends RestDocsOpenApiSpecTest {
                 questionUploadInfoJson.getBytes()      // 파일 내용
         );
 
-        System.out.println("QuestionUploadInfo: " + objectMapper.writeValueAsString(questionUploadInfo));
         MockMultipartFile questionImagesIn = new MockMultipartFile("questionImagesIn", "image1.png", "image/png", "image1".getBytes());
         MockMultipartFile questionImagesOut = new MockMultipartFile("questionImagesOut", "image2.png", "image/png", "image2".getBytes());
         MockMultipartFile commentaryImagesIn = new MockMultipartFile("commentaryImagesIn", "image3.png", "image/png", "image3".getBytes());
@@ -202,26 +200,6 @@ class QuestionsControllerOasTest extends RestDocsOpenApiSpecTest {
                 return request;
             }
         });
-
-//        //test
-//        MvcResult result = this.mockMvc.perform(
-//                        multipart("/api/v1/exams/{examId}/questions", userAddExamId)
-//                                .file(jsonPart)
-//                                .session(doLogin())
-//                )
-//                .andExpect(status().isCreated())
-//                .andDo(document("add-questions",
-//                        resource(ResourceSnippetParameters.builder()
-//                                .description("문제 추가")
-//                                .tag("question")
-//                                .summary("Add question")
-//                                .pathParameters(
-//                                        parameterWithName("examId").description("Exam id").type(SimpleType.INTEGER)
-//                                )
-//                                .build()
-//                        )))
-//
-//                .andReturn();
 
         this.mockMvc.perform(
                         customRestDocumentationRequestBuilder


### PR DESCRIPTION
## 변경사항
- 문제 추가, 수정, 삭제 시에 Cookie로 저장된 user정보를 토대로 해당 작업을 할 수 있는 권한을 확인합니다.

## 배경
- 본인이 생성한 시험에 한해서 문제 추가, 수정, 삭제가 가능해야합니다.

## 테스트 방법
- src/test/java/capstone/examlab.questions.controller.QuestionsControllerOasTest.java 테스트
- [http://localhost:8080/api/v1/](http://localhost:8080/api/v1/) 스웨거 확인

## 궁금한점
- Question Add 관련해서 ResourceSnippetParameters이 requestpart를 지원해주지 않아 정확한 내용이 문서화 되지 않았습니다. 이는 따로 작성해둔 노션 API내역을 확인해야합니다. 이외 read, update, delete는 잘 작동합니다

close #72 