### PR TITLE
[BE] Feature: TestContainer를 활용한 RepositoryTest 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     //Elasticsearch TestContainer
     testImplementation 'org.testcontainers:elasticsearch:1.19.3'
     testImplementation 'org.testcontainers:testcontainers:1.19.3'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation("org.testcontainers:junit-jupiter:1.12.0")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ tasks.named('test') {
     useJUnitPlatform() {
         includeTags 'basic_test'
         includeTags 'openapi_test'
-        excludeTags 'db_test'
+        includeTags 'db_test'
     }
 }
 

--- a/src/test/java/capstone/examlab/questions/repository/QuestionsRepositoryTest.java
+++ b/src/test/java/capstone/examlab/questions/repository/QuestionsRepositoryTest.java
@@ -1,54 +1,37 @@
 package capstone.examlab.questions.repository;
 
-import capstone.examlab.ExamLabApplication;
 import capstone.examlab.questions.dto.ImageDto;
+import capstone.examlab.questions.dto.QuestionsListDto;
+import capstone.examlab.questions.dto.search.QuestionsSearchDto;
+import capstone.examlab.questions.dto.upload.QuestionUploadInfo;
+
 import capstone.examlab.questions.entity.QuestionEntity;
 import capstone.examlab.questions.service.QuestionsService;
-
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.*;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.data.elasticsearch.DataElasticsearchTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
-import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.*;
 
-@SpringBootTest
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataElasticsearchTest
 @Tag("db_test")
 @Testcontainers
-class QuestionsRepositoryTest {
- /*   @Container
-    private static final ElasticsearchContainer container = new ElasticsearchContainer(
-            DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.11.3"))
-            .withPassword("elastic123")
-            .withReuse(true);
+public class QuestionsRepositoryTest {
+    private final static String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:7.17.5";
 
-    @Configuration
-    static class TestConfiguration extends ElasticsearchConfiguration {
-        @Override
-        public @NotNull ClientConfiguration clientConfiguration() {
+    @Container
+    @ServiceConnection
+    public static ElasticsearchContainer ES_CONTAINER = new ElasticsearchContainer(IMAGE_NAME);
 
-            return ClientConfiguration.builder()
-                    .connectedTo(container.getHttpHostAddress())
-                    .usingSsl(container.createSslContextFromCa())
-                    .withBasicAuth("elastic", "elastic123")
-                    .build();
-        }
-    }
-    @Mock
+    @Autowired
     private QuestionsRepository questionsRepository;
 
     @MockBean
@@ -57,148 +40,41 @@ class QuestionsRepositoryTest {
     @MockBean
     private BoolQueryBuilder boolQueryBuilder;
 
-    @MockBean
-    private ElasticsearchTemplate elasticsearchTemplate;
+    private final Long existExamId = 1L;
+
+    private final String questionUuid = "f8bd102d-c20a-4385-94f1-a4078843bg28";
+
+    @BeforeEach
+    public void setup(){
+        QuestionEntity question = QuestionEntity.builder()
+                .id(questionUuid)
+                .examId(existExamId)
+                .type("객관식")
+                .question("다음 중 총중량 1.5톤 피견인 승용자동차를 4.5톤 화물자동차로 견인하는 경우 필요한 운전면허에 해당하지 않은 것은?")
+                .options(List.of(
+                        "① 제1종 대형면허 및 소형견인차면허",
+                        "② 제1종 보통면허 및 대형견인차면허",
+                        "③ 제1종 보통면허 및 소형견인차면허",
+                        "④ 제2종 보통면허 및 대형견인차면허"))
+                .questionImagesIn(List.of(
+                        ImageDto.builder().url("url1").description("설명1").attribute("속성1").build()))
+                .questionImagesOut(List.of(
+                        ImageDto.builder().url("url2").description("설명2").attribute("속성2").build()))
+                .answers(List.of(4))
+                .commentary("도로교통법 시행규칙 별표18 총중량 750킬로그램을 초과하는 3톤 이하의 피견인 자동차를 견인하기 위해서는 견인 하는 자동차를 운전할 수 있는 면허와 소형견인차면허 또는 대형견인차면허를 가지고 있어야 한다.")
+                .commentaryImagesIn(List.of(
+                        ImageDto.builder().url("url3").description("설명3").attribute("속성3").build()))
+                .commentaryImagesOut(List.of(
+                        ImageDto.builder().url("url4").description("설명4").attribute("속성4").build()))
+                .tagsMap(Map.of("category", List.of("화물")))
+                .build();
+
+        System.out.println(questionsRepository.save(question).getId());
+    }
 
     @Test
-    void testRepository() {
-        ImageDto questionImagesOut = ImageDto.builder()
-                .url("https://examlab-image.s3.ap-northeast-2.amazonaws.com/driver_images/870.png")
-                .description("")
-                .attribute("examlab-image-right")
-                .build();
+    void testDatabaseIsRunning() {
+        assertThat(ES_CONTAINER.isRunning()).isTrue();
 
-        Map<String, List<String>> tagsMap = new HashMap<>();
-        tagsMap.put("category", List.of("법", "상황"));
-
-        QuestionEntity question = QuestionEntity.builder()
-                .id("4d51a532-3495-4fab-beef-27cc974c64b1")
-                .examId(1L)
-                .type("객관식")
-                .question("예시 문제1: 도로교통법령상, 포함된 단어 찾기 문제?")
-                .options(List.of(
-                        "① 규제표지이다.",
-                        "② 직진차량 우선표지이다.",
-                        "③ 좌합류 도로표지이다.",
-                        "④ 좌회전 금지표지이다."))
-                .answers(List.of(3))
-                .questionImagesOut(List.of(questionImagesOut))
-                .commentary("commentary 예시1")
-                .commentaryImagesIn(List.of())
-                .commentaryImagesOut(List.of())
-                .tagsMap(tagsMap)
-                .build();
-
-        questionsRepository.save(question);
-        //questionsService.deleteQuestionsByQuestionId(question.getId());
-        Optional<QuestionEntity> savedQuestion = questionsRepository.findById(question.getId());
-        assertThat(savedQuestion).isPresent();
-    }*/
-
-
-
-//
-//    @BeforeEach
-//    void addTestData() {
-//        List<QuestionEntity>questionEntities = new ArrayList<>();
-//        // 예시 1 생성
-//        ImageDto questionImagesOut = ImageDto.builder()
-//                .url("https://examlab-image.s3.ap-northeast-2.amazonaws.com/driver_images/870.png")
-//                .description("")
-//                .attribute("examlab-image-right")
-//                .build();
-//
-//        Map<String, List<String>> tagsMap = new HashMap<>();
-//        tagsMap.put("category", List.of("법", "상황"));
-//
-//        QuestionEntity question1 = QuestionEntity.builder()
-//                .id("4d51a532-3495-4fab-beef-27cc974c64b1")
-//                .examId(1L)
-//                .type("객관식")
-//                .question("예시 문제1: 도로교통법령상, 포함된 단어 찾기 문제?")
-//                .options(List.of(
-//                        "① 규제표지이다.",
-//                        "② 직진차량 우선표지이다.",
-//                        "③ 좌합류 도로표지이다.",
-//                        "④ 좌회전 금지표지이다."))
-//                .answers(List.of(3))
-//                .questionImagesOut(List.of(questionImagesOut))
-//                .commentary("commentary 예시1")
-//                .commentaryImagesIn(List.of())
-//                .commentaryImagesOut(List.of())
-//                .tagsMap(tagsMap)
-//                .build();
-//        questionEntities.add(question1);
-//        // 예시 2 생성
-//        ImageDto questionImagesOut2 = ImageDto.builder()
-//                .url("https://examlab-image.s3.ap-northeast-2.amazonaws.com/driver_images/872.png")
-//                .description("")
-//                .attribute("examlab-image-right")
-//                .build();
-//
-//        Map<String, List<String>> tagsMap2 = new HashMap<>();
-//        tagsMap2.put("category", List.of("법", "화물"));
-//        tagsMap2.put("year", List.of("20년도"));
-//
-//        QuestionEntity question2 = QuestionEntity.builder()
-//                .id("55cb3411-4b1d-4320-a46d-b8d36bb6b808")
-//                .examId(1L)
-//                .type("객관식")
-//                .question("예시 문제2 examLab화이팅 이 단어 포함되면 찾을 수 있는 로직은?")
-//                .options(List.of(
-//                        "① 보기1",
-//                        "② 보기2",
-//                        "③ 보기3",
-//                        "④ 보기4"))
-//                .answers(List.of(1))
-//                .questionImagesOut(List.of(questionImagesOut2))
-//                .commentary("commentary 예시2")
-//                .commentaryImagesIn(List.of())
-//                .commentaryImagesOut(List.of())
-//                .tagsMap(tagsMap2)
-//                .build();
-//        questionEntities.add(question2);
-//        questionsRepository.saveAll(questionEntities);
-//        System.out.println("Data size: " + questionsRepository.findByExamId(1L).size());
-//        assertThat(questionsRepository.findByExamId(1L).size()).isEqualTo(2);
-//    }
-//
-//    @Test
-//    void hi(){
-//
-//    }
-/*    @Test
-    void deleteQuestionsByExamId(){
-      //  assertThat(questionsRepository.findByExamId(1L).size()).isEqualTo(2);
-        boolean deleted = questionsService.deleteQuestionsByExamId(1L);
-        assertThat(deleted).isEqualTo(true);
-        assertThat(questionsRepository.findByExamId(1L).size()).isEqualTo(0);
-    }*/
-
-//    @Test
-//    void searchFromQuestionsTest() {
-//        Map<String, List<String>> tagsMap = new HashMap<>();
-//        tagsMap.put("category", List.of("법"));
-//        //tagsMap.put("year", List.of("20년도"));
-//
-//        List<String> includes = List.of("Lab화이팅");
-//
-//        assertThat(questionsRepository.findByExamId(1L).size()==2);
-//
-//        QuestionsSearch questionsSearch = QuestionsSearch.builder()
-//                .tagsMap(new HashMap<String, List<String>>())
-//                .includes(new ArrayList<>())
-//                .build();
-//
-//        QuestionsList questionsList = questionsService.searchFromQuestions(1L, questionsSearch);
-//
-//
-//        for (Question question : questionsList) {
-//            //assertThat(question.getTagsMap().get("category").contains("법"));
-//            //assertThat(question.getTagsMap().get("year").contains("20년도"));
-//            for (String include : includes) {
-//                assertThat(question.getQuestion().contains(include));
-//            }
-//        }
-//    }
+    }
 }

--- a/src/test/java/capstone/examlab/questions/repository/QuestionsRepositoryTest.java
+++ b/src/test/java/capstone/examlab/questions/repository/QuestionsRepositoryTest.java
@@ -31,7 +31,9 @@ import static org.awaitility.Awaitility.await;
 @Tag("db_test")
 @Testcontainers
 public class QuestionsRepositoryTest {
+    // 8.x SSL HTTPS ERROR -> 7.x HTTP
     private final static String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:7.17.5";
+    //private final static String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:8.11.3";
 
     @Container
     @ServiceConnection

--- a/src/test/java/capstone/examlab/questions/repository/QuestionsRepositoryTest.java
+++ b/src/test/java/capstone/examlab/questions/repository/QuestionsRepositoryTest.java
@@ -1,22 +1,25 @@
 package capstone.examlab.questions.repository;
 
 import capstone.examlab.questions.dto.ImageDto;
-import capstone.examlab.questions.dto.QuestionsListDto;
-import capstone.examlab.questions.dto.search.QuestionsSearchDto;
-import capstone.examlab.questions.dto.upload.QuestionUploadInfo;
-
+import org.junit.jupiter.api.Test;
 import capstone.examlab.questions.entity.QuestionEntity;
 import capstone.examlab.questions.service.QuestionsService;
 import org.junit.jupiter.api.*;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.data.elasticsearch.DataElasticsearchTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 
+import java.time.Duration;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +48,7 @@ public class QuestionsRepositoryTest {
     private final String questionUuid = "f8bd102d-c20a-4385-94f1-a4078843bg28";
 
     @BeforeEach
-    public void setup(){
+    public void setup() throws InterruptedException {
         QuestionEntity question = QuestionEntity.builder()
                 .id(questionUuid)
                 .examId(existExamId)
@@ -69,12 +72,34 @@ public class QuestionsRepositoryTest {
                 .tagsMap(Map.of("category", List.of("화물")))
                 .build();
 
-        System.out.println(questionsRepository.save(question).getId());
+        questionsRepository.save(question);
     }
 
     @Test
     void testDatabaseIsRunning() {
         assertThat(ES_CONTAINER.isRunning()).isTrue();
-
+        Optional<QuestionEntity> savedQuestion = questionsRepository.findById(questionUuid);
+        if (savedQuestion.isPresent()) {
+            QuestionEntity retrievedQuestion = savedQuestion.get();
+            System.out.println("retri questiosn: "+retrievedQuestion.getQuestion());
+        } else {
+            System.out.println("Question with UUID " + questionUuid + " not found.");
+        }
     }
+
+
+//    @Test
+//    void testDatabaseIsRunning() {
+//        assertThat(ES_CONTAINER.isRunning()).isTrue();
+//        assertThat(ES_CONTAINER.isRunning()).isTrue();
+//        // 페이지네이션 없이 모든 데이터를 조회하려면 PageRequest.of(0, Integer.MAX_VALUE)를 사용합니다.
+//        Page<QuestionEntity> allQuestions = questionsRepository.findAll(PageRequest.of(0, Integer.MAX_VALUE));
+//
+//        // 조회된 데이터 확인
+//        List<QuestionEntity> questionList = allQuestions.getContent();
+//        System.out.println(allQuestions.getSize());
+//        for (QuestionEntity question : questionList) {
+//            System.out.println(question.toString());
+//        }
+//    }
 }


### PR DESCRIPTION
## 변경사항
- DB repository test를 실제 DB가 아닌 임의의 test Image를 생성하여 테스트 DB를 생성합니다.

## 배경
- Test코드 내용이 실제 사용 DB에 영향을 미치면 안된다고 생각했습니다.

## 테스트 방법
- docker를 작동시킨 상태에서 테스트 가능합니다
- src/test/java/capstone/examlab/questions/repository/QuestionsRepositoryTest.java 테스트

## 궁금한점
- 실제 Elasticsearch DB는 8.x버전을 사용하지만 테스트에서 7.x버전을 사용하는 이유는 '8.x버전의 Auto SSL구성 및 HTTPS에서 실행 필요' 때문입니다. 
- 자세한 내용은 아래 Spring.io 이슈 내용 확인하면 도움 될 것 같습니다
[[Improve Elasticsearch ServiceConnection · Issue #35926 · spring-projects/spring-boot](https://github.com/spring-projects/spring-boot/issues/35926)](https://github.com/spring-projects/spring-boot/issues/35926)

close #69 