### PR TITLE
[BE] Feature: AI로 생성된 데이터를 저장 및 반환 할수 있다

### DIFF
--- a/src/main/java/capstone/examlab/exams/controller/ExamsController.java
+++ b/src/main/java/capstone/examlab/exams/controller/ExamsController.java
@@ -4,6 +4,10 @@ import capstone.examlab.ResponseDto;
 import capstone.examlab.exams.dto.*;
 import capstone.examlab.exams.service.ExamsService;
 import capstone.examlab.exhandler.exception.UnauthorizedException;
+import capstone.examlab.questions.dto.QuestionDto;
+import capstone.examlab.questions.dto.QuestionsListDto;
+import capstone.examlab.questions.dto.update.QuestionUpdateDto;
+import capstone.examlab.questions.service.QuestionsService;
 import capstone.examlab.users.argumentresolver.Login;
 import capstone.examlab.users.domain.User;
 import capstone.examlab.valid.ValidExamId;
@@ -11,9 +15,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 
 
 @Slf4j
@@ -85,4 +91,11 @@ public class ExamsController {
 
         return ResponseDto.OK;
     }
+
+//    //아래 가이드라인을 service에서 참조해서 사용하면 됩니다
+//    @PostMapping("/{examId}/ai")
+//    public QuestionsListDto addAIQuestionsByExamId(@PathVariable Long examId, @RequestBody List<QuestionUpdateDto> questionsUpdateListDto) {
+//        // AI 문제 추가 로직 실행
+//        return questionsService.addAIQuestionsByExamId(examId, questionsUpdateListDto);
+//    }
 }

--- a/src/main/java/capstone/examlab/questions/dto/upload/QuestionUploadInfo.java
+++ b/src/main/java/capstone/examlab/questions/dto/upload/QuestionUploadInfo.java
@@ -1,6 +1,7 @@
 package capstone.examlab.questions.dto.upload;
 
 import capstone.examlab.questions.dto.ImageDto;
+import capstone.examlab.questions.entity.QuestionEntity;
 import lombok.Builder;
 import lombok.Data;
 
@@ -20,4 +21,21 @@ public class QuestionUploadInfo {
     private List<ImageDto> commentaryImagesTextIn;
     private List<ImageDto> commentaryImagesTextOut;
     private Map<String, List<String>> tags;
+
+    public QuestionEntity toEntity( Long examId, String uuid) {
+        return QuestionEntity.builder()
+                .id(uuid)
+                .examId(examId)
+                .type(this.type)
+                .question(this.question)
+                .questionImagesIn(this.questionImagesTextIn)
+                .questionImagesOut(this.questionImagesTextOut)
+                .options(this.options)
+                .answers(this.answers)
+                .commentary(this.commentary)
+                .commentaryImagesIn(this.commentaryImagesTextIn)
+                .commentaryImagesOut(this.commentaryImagesTextOut)
+                .tagsMap(this.tags)
+                .build();
+    }
 }

--- a/src/main/java/capstone/examlab/questions/entity/QuestionEntity.java
+++ b/src/main/java/capstone/examlab/questions/entity/QuestionEntity.java
@@ -1,5 +1,6 @@
 package capstone.examlab.questions.entity;
 import capstone.examlab.questions.dto.ImageDto;
+import capstone.examlab.questions.dto.QuestionDto;
 import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Data;
@@ -38,4 +39,20 @@ public class QuestionEntity {
     private List<ImageDto> commentaryImagesOut;
     @Field(type = FieldType.Object)
     private Map<String, List<String>> tagsMap;
+
+    public QuestionDto toDto() {
+        return QuestionDto.builder()
+                .id(this.id)
+                .type(this.type)
+                .question(this.question)
+                .questionImagesIn(this.questionImagesIn)
+                .questionImagesOut(this.questionImagesOut)
+                .options(this.options)
+                .answers(this.answers)
+                .commentary(this.commentary)
+                .commentaryImagesIn(this.commentaryImagesIn)
+                .commentaryImagesOut(this.commentaryImagesOut)
+                .tags(this.tagsMap)
+                .build();
+    }
 }

--- a/src/main/java/capstone/examlab/questions/service/QuestionsService.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsService.java
@@ -20,4 +20,6 @@ public interface QuestionsService {
     boolean deleteQuestionsByExamId(Long examId);
 
     boolean deleteQuestionsByQuestionId(User user, String questionId);
+
+    QuestionsListDto addAIQuestionsByExamId(Long examId, List<QuestionUpdateDto> questionsUpdateListDto);
 }


### PR DESCRIPTION
## 변경사항
- QuestionService에 ai를 통해 생성된 문제를 저장하고 QuestionsListDto 형식으로 반환하는 메서드 생성했습니다.

## 배경
- AI로 생성된 문제를 저장하고 브라우저로 보내기. 위해 QuestionListDto로 반환해주는 메서드가 필요했습니다.

## 테스트 방법
- 생성예정

## 궁금한점
- QuestionUpdateDto -> QuestionEntity 생성시에 DTO메서드를 통해 변경할 수 있도록 78branch에 작업하겠습니다.
- ExamServiceImpl에서 사용할 QuestionsService 메서드의 예시를 ExamController에 구현 및 주석처리 해두었습니다.
- 아래 이미지는 실제로 List<QuestionUpdateDto>가 파라미터로 들어오면 생기는 데이터입니다
![image](https://github.com/LuizyHub/exam-lab/assets/120697456/c8200d88-f40f-4a71-9c8d-2f37d14f302a)

close #79  