### PR TITLE
[BE] Feature: Question API 수정, 데이터 변환 로직 위치 변경

### DIFF
--- a/src/main/java/capstone/examlab/exams/controller/ExamsController.java
+++ b/src/main/java/capstone/examlab/exams/controller/ExamsController.java
@@ -75,10 +75,7 @@ public class ExamsController {
             throw new UnauthorizedException();
         }
         examsService.deleteExam(examId, user);
-        boolean deleted = questionsService.deleteQuestionsByExamId(examId);
-        if (!deleted) {
-            return ResponseDto.BAD_REQUEST;
-        }
+        questionsService.deleteQuestionsByExamId(examId);
         return ResponseDto.OK;
     }
 

--- a/src/main/java/capstone/examlab/exams/controller/ExamsController.java
+++ b/src/main/java/capstone/examlab/exams/controller/ExamsController.java
@@ -30,7 +30,6 @@ public class ExamsController {
 
     private final ExamsService examsService;
 
-    // 임시로 활용
     private final QuestionsService questionsService;
 
     @GetMapping

--- a/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
+++ b/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
@@ -5,6 +5,7 @@ import capstone.examlab.exams.dto.*;
 import capstone.examlab.exams.repository.ExamRepository;
 import capstone.examlab.exhandler.exception.UnauthorizedException;
 import capstone.examlab.questions.dto.QuestionsListDto;
+import capstone.examlab.questions.service.QuestionsService;
 import capstone.examlab.users.domain.User;
 import capstone.examlab.valid.ValidExamId;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class ExamServiceImpl implements ExamsService {
 
     private final ObjectProvider<Exam> examProvider;
     private final ExamRepository examRepository;
+    private final QuestionsService questionsService;
 
     private static final String[] fileTypeList = {"text/plain", "text/markdown", "application/pdf"};
 

--- a/src/main/java/capstone/examlab/image/service/ImageServiceImpl.java
+++ b/src/main/java/capstone/examlab/image/service/ImageServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -25,8 +26,11 @@ public class ImageServiceImpl implements ImageService{
     @Transactional
     public String saveImageInS3(MultipartFile multipartImage){
         String originalName = multipartImage.getOriginalFilename();
+        String extension = originalName.substring(originalName.lastIndexOf("."));
+
+        String uuid = UUID.randomUUID().toString();
         String accessUrl = ""; //반환 URL저장
-        String filename = folderName+originalName;
+        String filename = folderName+ uuid + extension;
         try {
             ObjectMetadata objectMetadata = new ObjectMetadata();
             objectMetadata.setContentType(multipartImage.getContentType());

--- a/src/main/java/capstone/examlab/questions/controller/QuestionsController.java
+++ b/src/main/java/capstone/examlab/questions/controller/QuestionsController.java
@@ -115,11 +115,7 @@ public class QuestionsController {
         if (!examsService.isExamOwner(examId, user)) {
             throw new UnauthorizedException();
         }
-
-        boolean deleted = questionsService.deleteQuestionsByQuestionId(user, questionId);
-        if (!deleted) {
-            return ResponseDto.BAD_REQUEST;
-        }
+        questionsService.deleteQuestionsByQuestionId(user, questionId);
         return ResponseDto.OK;
     }
 }

--- a/src/main/java/capstone/examlab/questions/controller/QuestionsController.java
+++ b/src/main/java/capstone/examlab/questions/controller/QuestionsController.java
@@ -108,16 +108,6 @@ public class QuestionsController {
         return ResponseDto.OK;
     }
 
-    //Delete API with examId
-    @DeleteMapping("/exams/{examId}/questions")
-    public ResponseDto deleteQuestionsByExamId(@PathVariable @ValidExamId Long examId) {
-        boolean deleted = questionsService.deleteQuestionsByExamId(examId);
-        if (!deleted) {
-            return ResponseDto.BAD_REQUEST;
-        }
-        return ResponseDto.OK;
-    }
-
     //Delete Api with questionId
     @DeleteMapping("/questions/{questionId}")
     public ResponseDto deleteQuestionsByQuestionId(@Login User user, @PathVariable String questionId) {

--- a/src/main/java/capstone/examlab/questions/service/QuestionsService.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsService.java
@@ -22,7 +22,7 @@ public interface QuestionsService {
 
     boolean updateQuestionsByQuestionId(User user, QuestionUpdateDto questionsUpdateDto);
 
-    boolean deleteQuestionsByExamId(Long examId);
+    void deleteQuestionsByExamId(Long examId);
 
-    boolean deleteQuestionsByQuestionId(User user, String questionId);
+    void deleteQuestionsByQuestionId(User user, String questionId);
 }

--- a/src/main/java/capstone/examlab/questions/service/QuestionsService.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsService.java
@@ -18,6 +18,8 @@ public interface QuestionsService {
 
     QuestionsListDto searchFromQuestions(Long examId, QuestionsSearchDto questionsSearchDto);
 
+    Long getExamIDFromQuestion(String questionId);
+
     boolean updateQuestionsByQuestionId(User user, QuestionUpdateDto questionsUpdateDto);
 
     boolean deleteQuestionsByExamId(Long examId);

--- a/src/main/java/capstone/examlab/questions/service/QuestionsServiceImpl.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsServiceImpl.java
@@ -1,8 +1,6 @@
 package capstone.examlab.questions.service;
 
-import capstone.examlab.exams.service.ExamsService;
 import capstone.examlab.exhandler.exception.NotFoundQuestionException;
-import capstone.examlab.exhandler.exception.UnauthorizedException;
 import capstone.examlab.image.service.ImageService;
 import capstone.examlab.questions.dto.*;
 import capstone.examlab.questions.dto.search.QuestionsSearchDto;

--- a/src/main/java/capstone/examlab/questions/service/QuestionsServiceImpl.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsServiceImpl.java
@@ -150,23 +150,17 @@ public class QuestionsServiceImpl implements QuestionsService {
 
     //Delete 로직
     @Override
-    public boolean deleteQuestionsByExamId(Long examId) {
+    public void deleteQuestionsByExamId(Long examId) {
         questionsRepository.deleteByExamId(examId);
-
-        List<Question> questions = questionsRepository.findByExamId(examId);
-
-        return questions.isEmpty();
     }
 
     @Override
-    public boolean deleteQuestionsByQuestionId(User user, String questionId) {
+    public void deleteQuestionsByQuestionId(User user, String questionId) {
         Optional<Question> optionalQuestion = questionsRepository.findById(questionId);
         if (optionalQuestion.isPresent()) {
             questionsRepository.deleteById(questionId);
-            //삭제 검증
-            return !questionsRepository.existsById(questionId);
         } else {
-            return false;
+            throw new NotFoundQuestionException();
         }
     }
 }

--- a/src/main/resources/static/api/v1/openapi3.yaml
+++ b/src/main/resources/static/api/v1/openapi3.yaml
@@ -73,7 +73,7 @@ paths:
             examples:
               update-question:
                 value: "{\"question\":\"변경된 질문입니다.\",\"options\":[\"변경된 보기1\",\"변경\
-                  된 보기2\",\"변경된 보기3\",\"변경된 보기4\"],\"answers\":[1,3],\"id\":\"922af762-e356-4e1c-a498-4c05f6873a1c\"\
+                  된 보기2\",\"변경된 보기3\",\"변경된 보기4\"],\"answers\":[1,3],\"id\":\"337aae2c-b2b8-4b7f-9026-330fd6002aa3\"\
                   ,\"commentary\":\"변경된 설명입니다.\",\"tags\":{\"난이도\":[\"중\"],\"단원\"\
                   :[\"2\"]}}"
       responses:
@@ -82,7 +82,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
               examples:
                 update-question:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -100,10 +100,10 @@ paths:
               $ref: '#/components/schemas/api-v1-users-963924044'
             examples:
               user add:
-                value: "{\"password\":\"a9b06300-0e59-40a9-8640-a2a3fdbb4869!\",\"\
-                  password_confirm\":\"a9b06300-0e59-40a9-8640-a2a3fdbb4869!\",\"\
-                  user_id\":\"a9b06300-0e59-40a9-8640-a2a3fdbb4869@gmail.com\",\"\
-                  name\":\"a9b06300-0e59-40a9-8640-a2a3fdbb4869\"}"
+                value: "{\"password\":\"aca36f2f-f0a3-4db7-8d9c-4a2af92b996f!\",\"\
+                  password_confirm\":\"aca36f2f-f0a3-4db7-8d9c-4a2af92b996f!\",\"\
+                  user_id\":\"aca36f2f-f0a3-4db7-8d9c-4a2af92b996f@gmail.com\",\"\
+                  name\":\"aca36f2f-f0a3-4db7-8d9c-4a2af92b996f\"}"
       responses:
         "200":
           description: "200"
@@ -153,7 +153,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-questions486549215'
+              $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
             examples:
               patch-exams:
                 value: "{\"tags\":{\"난이도\":[\"상\",\"중\",\"하\",\"최하\"],\"단원\":[\"1\"\
@@ -164,7 +164,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
               examples:
                 patch-exams:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -187,7 +187,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
               examples:
                 delete-exams:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -211,7 +211,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
               examples:
                 delete-questions-by-questionId:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -371,7 +371,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
               examples:
                 post-file:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -397,7 +397,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
               examples:
                 delete-exam-file:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -450,7 +450,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-exams-examId-questions-1876066633'
               examples:
                 Search-questions:
-                  value: "{\"questions\":[{\"id\":\"b8ad77c7-215b-4be0-84aa-04c0aa852041\"\
+                  value: "{\"questions\":[{\"id\":\"ab185034-11ec-4030-a14f-50e48fea536c\"\
                     ,\"type\":\"객관식\",\"question\":\"소웨공 테스트 문제?\",\"question_images_in\"\
                     :[],\"question_images_out\":[],\"options\":[\"① 답 예시 1\",\"② 답\
                     \ 예시 2\",\"③ 답 예시 3\",\"④ 답 예시 4\"],\"answers\":[3],\"commentary\"\
@@ -487,23 +487,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-questions486549215'
+                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
               examples:
                 add-questions:
-                  value: "{\"code\":201,\"message\":{\"id\":\"40f678ab-bf43-433e-a7f8-d5d7f5e9f5c8\"\
+                  value: "{\"code\":201,\"message\":{\"id\":\"73e5c4b4-c4a1-4c6c-9168-7646716c3f18\"\
                     ,\"type\":\"객관식\",\"question\":\"다음 중 총중량 1.5톤 피견인 승용자동차를 4.5톤\
                     \ 화물자동차로 견인하는 경우 필요한 운전면허에 해당하지 않은 것은?\",\"question_images_in\"\
-                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/image1.png\"\
+                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/11d199d9-3fa9-46e0-a5e7-8a325307347e.png\"\
                     ,\"description\":\"설명1\",\"attribute\":\"속성1\"}],\"question_images_out\"\
-                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/image2.png\"\
+                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/3e5a2c79-7d5f-40b0-91c8-7fc5b36e797f.png\"\
                     ,\"description\":\"설명2\",\"attribute\":\"속성2\"}],\"options\":[\"\
                     ① 제1종 대형면허 및 소형견인차면허\",\"② 제1종 보통면허 및 대형견인차면허\",\"③ 제1종 보통면허 및\
                     \ 소형견인차면허\",\"④ 제2종 보통면허 및 대형견인차면허\"],\"answers\":[4],\"commentary\"\
                     :\"도로교통법 시행규칙 별표18 총중량 750킬로그램을 초과하는 3톤 이하의 피견인 자동차를 견인하기 위해서는\
                     \ 견인 하는 자동차를 운전할 수 있는 면허와 소형견인차면허 또는 대형견인차면허를 가지고 있어야 한다.\",\"\
-                    commentary_images_in\":[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/image3.png\"\
+                    commentary_images_in\":[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/e9ed37de-6ad5-44f7-99c6-c4f4c759586d.png\"\
                     ,\"description\":\"설명3\",\"attribute\":\"속성3\"}],\"commentary_images_out\"\
-                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/image4.png\"\
+                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/146d5278-9b22-4128-94cb-fbd722b10e4f.png\"\
                     ,\"description\":\"설명4\",\"attribute\":\"속성4\"}],\"tags\":{}}}"
 components:
   schemas:
@@ -606,27 +606,6 @@ components:
         user_id:
           type: string
           description: User id
-    ExamFile:
-      title: ExamFile
-      required:
-      - code
-      type: object
-      properties:
-        code:
-          type: number
-          description: 응답 코드
-        message:
-          required:
-          - exist
-          - file_title
-          type: object
-          properties:
-            exist:
-              type: boolean
-              description: 파일 존재 여부
-            file_title:
-              type: string
-              description: File title
     api-v1-exams-examId-questions-1876066633:
       required:
       - questions
@@ -770,6 +749,27 @@ components:
                       - type: string
                       - type: number
                 description: 문제의 태그 맵 정보
+    ExamFile:
+      title: ExamFile
+      required:
+      - code
+      type: object
+      properties:
+        code:
+          type: number
+          description: 응답 코드
+        message:
+          required:
+          - exist
+          - file_title
+          type: object
+          properties:
+            exist:
+              type: boolean
+              description: 파일 존재 여부
+            file_title:
+              type: string
+              description: File title
     AiQuestions:
       title: AiQuestions
       type: object
@@ -798,7 +798,7 @@ components:
         login:
           type: boolean
           description: 로그인 여부
-    api-v1-questions486549215:
+    api-v1-exams-examId-file486549215:
       type: object
     api-v1-users-963924044:
       required:

--- a/src/test/java/capstone/examlab/questions/controller/QuestionsControllerOasTest.java
+++ b/src/test/java/capstone/examlab/questions/controller/QuestionsControllerOasTest.java
@@ -117,7 +117,7 @@ class QuestionsControllerOasTest extends RestDocsOpenApiSpecTest {
     @AfterEach
     void tearDown() throws Exception {
         this.mockMvc.perform(
-                        delete("/api/v1/exams/{examId}/questions", userAddExamId)
+                        delete("/api/v1/exams/{examId}", userAddExamId)
                                 .session(doLogin())
                 )
                 .andExpect(status().isOk());


### PR DESCRIPTION
## 변경사항
 - Bean 참조 로직 재설계 및 적용
- deleteExam API에 deleteQuestions 메서드 연결

## 배경
- ExamService, QuestoinService에서 발생한 순환 참조 문제를 해결해야 했습니다
- 시험 삭제시에 해당 시험 ID에 해당하는 문제들도 삭제되어야 합니다

## 테스트 방법
- src/test/java/capstone/examlab/questions/controller/QuestionsControllerOasTest.java

## 궁금한점
- 아래와 같이 참조 변경했습니다
<img width="661" alt="image" src="https://github.com/LuizyHub/exam-lab/assets/120697456/fc49cb55-5b97-45e0-b26f-611aa99f5cf7">

close #85    