### PR TITLE
[FE] 나만의 시험지 에디터 컴포넌트를 생성 삭제 할 수 있다.

### DIFF
--- a/src/components/EditorComment.js
+++ b/src/components/EditorComment.js
@@ -6,7 +6,7 @@ import EditorTool from '../components/EditorTool';
 
 import axios from 'axios';
 
-export default function EditorExam({ number }) {
+export default function EditorComment({ number }) {
   //from import
   const { isImageSize, handleImgSize, handleImageSelect } = useImage();
   const { handleFileObject, handleIdContent, imageReplace } = handleData();

--- a/src/components/EditorExam.js
+++ b/src/components/EditorExam.js
@@ -35,7 +35,7 @@ export default function EditorExam() {
 
   const sendPostData = () => {
 
-    const URL = '/api/v1/exams/3/questions'
+    const URL = '/api/v1/exams/11/questions'
     const formData = new FormData();
 
     const questionImagesTextIn = [];
@@ -84,7 +84,7 @@ export default function EditorExam() {
         console.log(response.data.message);
         console.log(response.data);
         const message = response.data.message;
-        setID(message);
+        setID(message.id);
       })
       .catch((error) => {
         console.log(error);
@@ -95,8 +95,9 @@ export default function EditorExam() {
     console.log("삭제");
     console.log(isUrlIn);
     console.log(ID);
-    const URL = `/api/v1/questions/${ID}`
-    // const URL = `/api/v1/questions/671eb7d7-2cc6-446d-8790-83cb0bd8cddc`
+    // const URL = `/api/v1/questions/${ID}`
+    const URL = `/api/v1/questions/2a5ef27f-e6c6-4cec-8c7e-9cfa31fb2fd4`
+    // console.log(ID)
     axios.delete(URL, {
     })
       .then((response) => {

--- a/src/components/EditorExam.js
+++ b/src/components/EditorExam.js
@@ -6,7 +6,7 @@ import EditorTool from '../components/EditorTool';
 
 import axios from 'axios';
 
-export default function EditorExam() {
+export default function EditorExam({ number }) {
   //from import
   const { isImageSize, handleImgSize, handleImageSelect } = useImage();
   const { handleFileObject, handleIdContent, imageReplace } = handleData();
@@ -32,6 +32,10 @@ export default function EditorExam() {
   });
 
   const [ID, setID] = useState("");
+  const [isResQuestion, setResQuestion] = useState("");
+  const [isResOption, setResOption] = useState([]);
+  const [isResUrlIn, setResUrlIn] = useState([]);
+  const [isResUrlOut, setResUrlOut] = useState([]);
 
   const sendPostData = () => {
 
@@ -85,6 +89,12 @@ export default function EditorExam() {
         console.log(response.data);
         const message = response.data.message;
         setID(message.id);
+        setResQuestion(message.question);
+        setResOption(message.options);
+        // setResOption(prevOption => [...prevOption, ...message.option]);
+        setResUrlIn(message.question_images_in.map(image => image.url));
+        // console.log(message.question_images_in[0].url);
+        setResUrlOut(message.question_images_out.map(image => image.url));
       })
       .catch((error) => {
         console.log(error);
@@ -95,8 +105,8 @@ export default function EditorExam() {
     console.log("삭제");
     console.log(isUrlIn);
     console.log(ID);
-    // const URL = `/api/v1/questions/${ID}`
-    const URL = `/api/v1/questions/2a5ef27f-e6c6-4cec-8c7e-9cfa31fb2fd4`
+    const URL = `/api/v1/questions/${ID}`
+    // const URL = `/api/v1/questions/6f9a1418-a3c8-4c0b-91a3-7a461164dcf6`
     // console.log(ID)
     axios.delete(URL, {
     })
@@ -132,7 +142,18 @@ export default function EditorExam() {
       });
   }
 
+  const imgRegex = /<img[^>]*>/ig;
+  let imgIndex = 0;
+  const replacedQuestion = isResQuestion.replace(imgRegex, () => {
+    // 이미지의 번호를 1부터 시작하여 증가시킵니다.
+    imgIndex++;
+
+    return `<img src='${isResUrlIn[imgIndex - 1]}' style= "width:5%;" />`;
+  })
+
+  console.log(replacedQuestion)
   return (
+
     <div>
       {/* <select value={contentType1} onChange={handleContentType1}>
         <option value="type">Select</option>
@@ -140,6 +161,21 @@ export default function EditorExam() {
         <option value="이미지">이미지</option>
         <option value="선택지">선택지</option>
       </select> */}
+
+      <div>
+        <h1>Show</h1>
+        <p>{number}</p>
+        <p dangerouslySetInnerHTML={{ __html: replacedQuestion }} />
+        {/* {isResUrlIn.map((URL, index) => (
+          <img key={index} src={URL} style={{ width: '25%' }} />
+        ))} */}
+        {isResUrlOut.map((URL, index) => (
+          <img key={index} src={URL} style={{ width: '25%' }} />
+        ))}
+        {isResOption.map((options, index) => (
+          <p key={index}>{options}</p>
+        ))}
+      </div>
 
       <EditorTool
         editorRef={editorRef1}
@@ -165,8 +201,8 @@ export default function EditorExam() {
           setUrlIn(prevState => [...prevState, result]);
           setUrlInId(prevState => [...prevState, result.name])
           //업로드 되면서 공백 없이 바로 question에 존재하는 html입력 값을 확인
-          const isQuestion = editorRef1.current.innerHTML;//
-          const imageReplaceResult = imageReplace(isQuestion);
+          const isResQuestion = editorRef1.current.innerHTML;//
+          const imageReplaceResult = imageReplace(isResQuestion);
           console.log(imageReplaceResult);
           setData(
             prevState => ({
@@ -213,8 +249,8 @@ export default function EditorExam() {
 
 
         onInput={() => {
-          const isQuestion = editorRef1.current.innerHTML;
-          const imageReplaceResult = imageReplace(isQuestion);
+          const isResQuestion = editorRef1.current.innerHTML;
+          const imageReplaceResult = imageReplace(isResQuestion);
           console.log(imageReplaceResult);
           setData(
             prevState => ({
@@ -359,6 +395,7 @@ export default function EditorExam() {
           }
         }} // 이미지 붙여넣기 동작 막기
 
+        dangerouslySetInnerHTML={{ __html: '1<br>2<br>3<br>4' }}
 
         onInput={() => {
           const isOptions = editorRef3.current.innerHTML;
@@ -384,6 +421,8 @@ export default function EditorExam() {
 
       <button type='submit' onClick={() => {
         sendPostData();
+        console.log(isResOption);
+        console.log(isResUrlIn);
       }}>생성</button>
       <button onClick={() => {
         sendDeleteData();

--- a/src/components/EditorExam.js
+++ b/src/components/EditorExam.js
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { handleToolClick, handleImgToolClick } from '../function/toolHandle';
 import { useImage } from '../function/useImage';
-import { dataHandle } from '../function/dataHandle';
+import { handleData } from '../function/handleData';
 import EditorTool from '../components/EditorTool';
 
 import axios from 'axios';
@@ -9,7 +9,7 @@ import axios from 'axios';
 export default function EditorExam() {
   //from import
   const { isImageSize, handleImgSize, handleImageSelect } = useImage();
-  const { handleFileObject, handleIdContent, imageReplace } = dataHandle();
+  const { handleFileObject, handleIdContent, imageReplace } = handleData();
   // const { sendPostData } = formData();
 
   const imageSelectorRef1 = useRef(null); // 파일 선택 input 요소에 접근에 대한 참조

--- a/src/components/Navigate.js
+++ b/src/components/Navigate.js
@@ -11,7 +11,7 @@ export default function Navigate() {
                 </div>
                 <div className="nav-item">
                     <img src="/img/시험지제작.png" alt="Main Image" className="nav-icon" />
-                    <Link to='/editR' className="nav-link">나만의 시험지</Link>
+                    <Link to='/exams/3' className="nav-link">나만의 시험지</Link>
                 </div>
             </nav>
         </div>

--- a/src/components/ShowQuestionList.js
+++ b/src/components/ShowQuestionList.js
@@ -5,7 +5,7 @@ import SelectedQuestionList from "./SelectedQuestionList";
 import '../css/ShowQuestionList.css'
 
 
-export default function ShowQuestionList({questions}){
+export default function ShowQuestionList({ questions }) {
 
 
     const navigate = useNavigate();
@@ -13,14 +13,14 @@ export default function ShowQuestionList({questions}){
     const [showSelectedList, setShowSelectedList] = useState(true);
 
 
-     // 처음 렌더링될 때 모든 문제를 선택된 문제 리스트에 추가
-     useEffect(() => {
+    // 처음 렌더링될 때 모든 문제를 선택된 문제 리스트에 추가
+    useEffect(() => {
         setSelectedQuestions(questions);
     }, [questions]);
 
 
-     // 문제 선택 핸들러
-     const handleSelectQuestion = (item) => {
+    // 문제 선택 핸들러
+    const handleSelectQuestion = (item) => {
         // 이미 선택된 문제인지 확인
         const isAlreadySelected = selectedQuestions.find(q => q.id === item.id);
 
@@ -35,26 +35,26 @@ export default function ShowQuestionList({questions}){
 
     // 시험지 생성 버튼을 누르면, 선택된 문제 리스트가 LabExam으로 넘어간다. 
     const handleSubmitQuestion = () => {
-        navigate('../lab', {state : {selectedQuestions}})
+        navigate('../workbooks/create', { state: { selectedQuestions } })
 
     }
 
 
 
-return (
-    <div>
-         <button onClick={handleSubmitQuestion} style={{ padding: '10px 20px', backgroundColor: '#5BB6B4', color: 'white', border: 'none', borderRadius: '5px', marginBottom: '20px', cursor: 'pointer' }}>시험지 생성</button>
-    <div style={{ display: 'flex', flexDirection: 'row' }}>
-        
-    {/* 선택된 문제 리스트 */}
-    <div style={{ flex: 2, marginLeft: showSelectedList ? 0 : '-200px', transition: 'margin 0.3s', marginRight: '20px', listStylePosition: 'inside', height: '100vh', backgroundColor: '#f0f0f0', padding: '20px', borderRadius: '10px' }}>
-       
-        <button style={{ padding: '10px 0px', marginLeft: '300px'}} onClick={() => setShowSelectedList(!showSelectedList)}>
-                    {showSelectedList ? 'X' : '+'}
-                </button>
-        <h2 style={{ marginBottom: '20px', borderBottom: '2px solid #333', textAlign: 'center' }}>선택된 문제 리스트</h2>
-        <ol style={{ padding: 0 }}>
-        {selectedQuestions.map((item, index) => (
+    return (
+        <div>
+            <button onClick={handleSubmitQuestion} style={{ padding: '10px 20px', backgroundColor: '#5BB6B4', color: 'white', border: 'none', borderRadius: '5px', marginBottom: '20px', cursor: 'pointer' }}>시험지 생성</button>
+            <div style={{ display: 'flex', flexDirection: 'row' }}>
+
+                {/* 선택된 문제 리스트 */}
+                <div style={{ flex: 2, marginLeft: showSelectedList ? 0 : '-200px', transition: 'margin 0.3s', marginRight: '20px', listStylePosition: 'inside', height: '100vh', backgroundColor: '#f0f0f0', padding: '20px', borderRadius: '10px' }}>
+
+                    <button style={{ padding: '10px 0px', marginLeft: '300px' }} onClick={() => setShowSelectedList(!showSelectedList)}>
+                        {showSelectedList ? 'X' : '+'}
+                    </button>
+                    <h2 style={{ marginBottom: '20px', borderBottom: '2px solid #333', textAlign: 'center' }}>선택된 문제 리스트</h2>
+                    <ol style={{ padding: 0 }}>
+                        {selectedQuestions.map((item, index) => (
                             <li key={index} className="slide-item">
                                 <ShowQuestion
                                     question={item.question}
@@ -65,31 +65,32 @@ return (
                                 />
                             </li>
                         ))}
-        </ol>
-    </div>
+                    </ol>
+                </div>
 
 
-    {/* 문제 고르기 */}
-    <div style={{ flex: 8, height: '100vh', padding: '20px', backgroundColor: '#f9f9f9', borderRadius: '10px' }}>
-        <h2 style={{ marginBottom: '20px', borderBottom: '2px solid #333', textAlign:'center' }}>문제 고르기</h2>
-        {Array.isArray(questions) && questions.length > 0 ? (
-            <ol style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px', listStylePosition: 'inside', padding: 0 }}>
-                {questions.map((item, index) => (
-                    <li key={index} style={{ marginBottom: '20px', padding: '20px', borderRadius: '10px', backgroundColor: '#fff', boxShadow: '0px 0px 10px rgba(0, 0, 0, 0.1)', cursor: 'pointer' }} onClick={() => handleSelectQuestion(item)}>
-                        <ShowQuestion
-                            question={item.question}
-                            question_images_out={item.question_images_out}
-                            question_images_in={item.question_images_in}
-                            options={item.options}
-                        />
-                    </li>
-                ))}
-            </ol>
-        ) : (
-            <p style={{ textAlign: 'center' }}>원하는 문제를 선택해주세요.</p>
-        )}
-    </div>
-</div>
-</div>
+                {/* 문제 고르기 */}
+                <div style={{ flex: 8, height: '100vh', padding: '20px', backgroundColor: '#f9f9f9', borderRadius: '10px' }}>
+                    <h2 style={{ marginBottom: '20px', borderBottom: '2px solid #333', textAlign: 'center' }}>문제 고르기</h2>
+                    {Array.isArray(questions) && questions.length > 0 ? (
+                        <ol style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px', listStylePosition: 'inside', padding: 0 }}>
+                            {questions.map((item, index) => (
+                                <li key={index} style={{ marginBottom: '20px', padding: '20px', borderRadius: '10px', backgroundColor: '#fff', boxShadow: '0px 0px 10px rgba(0, 0, 0, 0.1)', cursor: 'pointer' }} onClick={() => handleSelectQuestion(item)}>
+                                    <ShowQuestion
+                                        question={item.question}
+                                        question_images_out={item.question_images_out}
+                                        question_images_in={item.question_images_in}
+                                        options={item.options}
+                                    />
+                                </li>
+                            ))}
+                        </ol>
+                    ) : (
+                        <p style={{ textAlign: 'center' }}>원하는 문제를 선택해주세요.</p>
+                    )}
+                </div>
+            </div>
+        </div>
 
-);}
+    );
+}

--- a/src/function/handleData.js
+++ b/src/function/handleData.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import parse from 'html-react-parser';
 
-export const dataHandle = () => {
+export const handleData = () => {
   // 이미지 추적 후 여기에 html로 저장이 될 수는 함수
 
   //이미지의 url만 저장되는 코드
@@ -32,7 +32,7 @@ export const dataHandle = () => {
       }
     });
 
-    if (!hasImages && (elementImage.length > 0)) {//isImageId.length > 0 || 
+    if (!hasImages && (elementImage.length > 0)) {
       console.log('이미지가 포함되지 않았습니다. 이미지 ID와 URL을 초기화합니다.');
       updatedImageUrls = [];
     } else {

--- a/src/function/useImage.js
+++ b/src/function/useImage.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 export const useImage = () => {
 
@@ -47,24 +47,6 @@ export const useImage = () => {
 
     return files[0]; //항상 배열로 넘겨줘야함
   };
-
-  // // 이미지를 렌더링하는 함수, 여기서 이미지 url을 알 수 있다.
-  // const readImageData = (file, elementRef) => {
-  //   // 이미지 파일을 읽어들임
-  //   const reader = new FileReader();
-  //   reader.onload = function (e) {
-  //     const imageDataUrl = e.target.result; //여기서 const여야 하는 이유는?우선 한번 이미지를렌더링 할 때 변경할 필요가 없기 때문이다.
-  //     setUrl(imageDataUrl);
-
-  //     // 이미지 삽입
-  //     insertImageConfig(imageDataUrl, elementRef);//어떤 영역에 읽어 드릴지 정해야 해서 elementRef를 인자로 두어야 한다.
-  //     console.log(`url : ${exportUrl}`)
-  //   };
-  //   reader.readAsDataURL(file, elementRef);
-
-  // }
-
-  //나중에 export
 
   // 이미지 삽입, 이미지 설정 함수
   const insertImageConfig = (elementRef, imageDataUrl, elementName) => {

--- a/src/function/useImage.js
+++ b/src/function/useImage.js
@@ -52,6 +52,7 @@ export const useImage = () => {
   const insertImageConfig = (elementRef, imageDataUrl, elementName) => {
 
     const imgElement = document.createElement('img');
+    const buttonElement = document.createElement('button'); // 버튼 엘리먼트 생성
 
     imgElement.setAttribute('id', elementName); // 이미지에 아이디 설정
     imgElement.src = imageDataUrl;
@@ -68,9 +69,19 @@ export const useImage = () => {
       // console.log(e.target);
     };
     console.log(imgElement);
+
+    // 버튼 설정
+    buttonElement.textContent = 'Delete'; // 버튼 텍스트 설정
+    buttonElement.onclick = (e) => {
+      // 버튼 클릭 시 이미지 삭제 로직 추가
+      imgElement.remove();
+      buttonElement.remove();
+    };
+
     // 에디터에 이미지 DOM에 삽입 -> 여기를 해결...
     if (elementRef.current) {
       elementRef.current.appendChild(imgElement);
+      elementRef.current.appendChild(buttonElement); // 버튼 삽입
     } else {
       console.error("Editor reference is null.");
     }

--- a/src/function/useLoginController.js
+++ b/src/function/useLoginController.js
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+export const useLoginController = () => {
+
+  const [userName, setUserName] = useState('');
+  const [loginStatus, setLoginStatus] = useState(false);
+
+  // 클릭시 자동 로그인
+  // 개발을 위한 목적, 추후 삭제
+  const handleAutoLogin = async () => {
+    try {
+      const response = await axios.post('/api/v1/users/login', {
+        "password": "lab111!",
+        "user_id": "lab1@gmail.com"
+      });
+      alert(response.statusText)
+      return console.log('Login successful', response.statusText);
+    } catch (error) {
+      alert(error)
+      return console.error('Login failed', error);
+    }
+  };
+
+  // 로그아웃 버튼
+  const handleLogout = async () => {
+    try {
+      const response = await axios.post('/api/v1/users/logout');
+      console.log("Logout successful", response);
+      alert('Logout');
+      setLoginStatus(false);
+
+    } catch (error) {
+      console.error('Logout failed', error);
+    }
+  }
+
+  // 로그인 상태 받아오기
+  const handleLoginState = async () => {
+    try {
+      const response = await axios.get('/api/v1/users/status');
+      alert('Login successful');
+      console.log('Login successful', response);
+      const { user_name, login } = response.data;
+      console.log('User name:', user_name);
+      console.log('Login status:', login);
+      setUserName(user_name);
+      setLoginStatus(login);
+    } catch (error) {
+      console.error('Login failed', error);
+      // 401 에러가 발생하면 로그인되지 않았음을 알리는 알림창을 띄운다.
+      if (error.response && error.response.status === 401) {
+        alert('Fail to Login, Try to Login');
+
+      }
+    }
+  };
+
+  return { handleAutoLogin, handleLogout, handleLoginState }
+
+}

--- a/src/page/EditExam.js
+++ b/src/page/EditExam.js
@@ -29,14 +29,15 @@ export default function EditExam() {
       >생성</button>
 
       {isCreate.map((component, index) => (
-        <div style={{ marginTop: '40px', padding: '16px 24px', border: '1px solid #D6D6D6', borderRadius: '4px', width: '700px' }}>
-          <button onClick={() => handleDelete(index)}>삭제</button>
-          <div key={index}>{component}</div>
+        <div key={index} style={{ marginTop: '40px' }}>
+          <div key={index} style={{ padding: '16px 24px', border: '1px solid #D6D6D6', borderRadius: '4px', width: '700px' }}>
+            <button style={{ marginLeft: '80%' }} onClick={() => handleDelete(index)}>템플릿 삭제</button>
+
+            <div key={index}>{component}</div>
+
+          </div>
         </div>
       ))}
-
-
-
 
       {/* <EditorExam></EditorExam>
       <EditorExam></EditorExam> */}

--- a/src/page/EditExam.js
+++ b/src/page/EditExam.js
@@ -9,7 +9,7 @@ export default function EditExam() {
 
   const handleCreate = () => {
     // 새로운 컴포넌트를 생성하여 상태에 추가
-    setCreate([...isCreate, <EditorExam key={isCreate.length} />]);
+    setCreate([...isCreate, <EditorExam key={isCreate.length} number={isCreate.length + 1} />]);
   };
 
   const handleDelete = (elementIndex) => {
@@ -22,13 +22,14 @@ export default function EditExam() {
   return (
     <>
       <h1>Test</h1>
+      <button>시험지 생성</button>
       <AttributeManager></AttributeManager>
       {/* AttributeManager 저장하기가 되어야 EditorExam이 활성화 */}
-      <button
-        onClick={handleCreate}
-      >생성</button>
 
-      {isCreate.map((component, index) => (
+      <button
+        onClick={() => { handleCreate(); console.log(isCreate.length); }}
+      >생성</button>
+      {isCreate.reverse().map((component, index) => (
         <div key={index} style={{ marginTop: '40px' }}>
           <div key={index} style={{ padding: '16px 24px', border: '1px solid #D6D6D6', borderRadius: '4px', width: '700px' }}>
             <button style={{ marginLeft: '80%' }} onClick={() => handleDelete(index)}>템플릿 삭제</button>
@@ -39,8 +40,7 @@ export default function EditExam() {
         </div>
       ))}
 
-      {/* <EditorExam></EditorExam>
-      <EditorExam></EditorExam> */}
+
     </>
   )
 }

--- a/src/page/EditExam.js
+++ b/src/page/EditExam.js
@@ -6,9 +6,17 @@ import { useState } from "react";
 
 export default function EditExam() {
   const [isCreate, setCreate] = useState([]);
+
   const handleCreate = () => {
     // 새로운 컴포넌트를 생성하여 상태에 추가
     setCreate([...isCreate, <EditorExam key={isCreate.length} />]);
+  };
+
+  const handleDelete = (elementIndex) => {
+    // 인덱스를 사용하여 삭제할 컴포넌트를 제외한 배열을 만듭니다.
+    const deleteElement = isCreate.filter((_, index) => index !== elementIndex);
+    // 변경된 배열을 상태에 적용합니다.
+    setCreate(deleteElement);
   };
 
   return (
@@ -16,16 +24,18 @@ export default function EditExam() {
       <h1>Test</h1>
       <AttributeManager></AttributeManager>
       {/* AttributeManager 저장하기가 되어야 EditorExam이 활성화 */}
-
-      <div style={{ marginTop: '40px', padding: '16px 24px', border: '1px solid #D6D6D6', borderRadius: '4px', width: '700px' }}>
-        {isCreate.map((component, index) => (
-          <div key={index}>{component}</div>
-        ))}
-      </div>
-
       <button
         onClick={handleCreate}
       >생성</button>
+
+      {isCreate.map((component, index) => (
+        <div style={{ marginTop: '40px', padding: '16px 24px', border: '1px solid #D6D6D6', borderRadius: '4px', width: '700px' }}>
+          <button onClick={() => handleDelete(index)}>삭제</button>
+          <div key={index}>{component}</div>
+        </div>
+      ))}
+
+
 
 
       {/* <EditorExam></EditorExam>

--- a/src/page/EditExam.js
+++ b/src/page/EditExam.js
@@ -1,14 +1,33 @@
 // import { useRef } from "react";
 import EditorExam from "../components/EditorExam"
 import AttributeManager from "../components/AttributeManager"
+import { useState } from "react";
 // import { useDataHandle } from "../..//dataHandle";
+
 export default function EditExam() {
+  const [isCreate, setCreate] = useState([]);
+  const handleCreate = () => {
+    // 새로운 컴포넌트를 생성하여 상태에 추가
+    setCreate([...isCreate, <EditorExam key={isCreate.length} />]);
+  };
+
   return (
     <>
       <h1>Test</h1>
       <AttributeManager></AttributeManager>
       {/* AttributeManager 저장하기가 되어야 EditorExam이 활성화 */}
-      <EditorExam></EditorExam>
+
+      <div style={{ marginTop: '40px', padding: '16px 24px', border: '1px solid #D6D6D6', borderRadius: '4px', width: '700px' }}>
+        {isCreate.map((component, index) => (
+          <div key={index}>{component}</div>
+        ))}
+      </div>
+
+      <button
+        onClick={handleCreate}
+      >생성</button>
+
+
       {/* <EditorExam></EditorExam>
       <EditorExam></EditorExam> */}
     </>

--- a/src/page/EditExam.js
+++ b/src/page/EditExam.js
@@ -2,9 +2,14 @@
 import EditorExam from "../components/EditorExam"
 import AttributeManager from "../components/AttributeManager"
 import { useState } from "react";
+import { useLoginController } from "../function/useLoginController";
 // import { useDataHandle } from "../..//dataHandle";
 
 export default function EditExam() {
+
+  //로그인 리모컨
+  const { handleAutoLogin, handleLogout, handleLoginState } = useLoginController();
+
   const [isCreate, setCreate] = useState([]);
 
   const handleCreate = () => {
@@ -22,6 +27,11 @@ export default function EditExam() {
   return (
     <>
       <h1>Test</h1>
+      <div style={{ marginBottom: '40px' }}>
+        <button style={{ backgroundColor: 'gray', color: 'white' }} onClick={() => { handleAutoLogin() }}>logIn</button>
+        <button style={{ backgroundColor: 'gray', color: 'white' }} onClick={() => { handleLogout() }}>logOut</button>
+        <button style={{ backgroundColor: 'gray', color: 'white' }} onClick={() => { handleLoginState() }}>logState</button>
+      </div>
       <button>시험지 생성</button>
       <AttributeManager></AttributeManager>
       {/* AttributeManager 저장하기가 되어야 EditorExam이 활성화 */}

--- a/src/page/MainPage.js
+++ b/src/page/MainPage.js
@@ -83,7 +83,7 @@ export default function MainPage() {
                     <Link to='/exams' style={{ textDecoration: 'none', color: 'inherit' }}>시험지 제작하기</Link>
                 </button>
                 <button className='myExam-navigate-button'>
-                    <Link to='/editR' style={{ textDecoration: 'none', color: 'inherit' }}>나만의 시험지</Link>
+                    <Link to='/exams/3' style={{ textDecoration: 'none', color: 'inherit' }}>나만의 시험지</Link>
                 </button>
             </nav>
 

--- a/src/test/english/englishExam.js
+++ b/src/test/english/englishExam.js
@@ -32,26 +32,26 @@ export default function EnglishExam() {
     return parsedText;
   };
 
-// 표를 처리하는 함수
-const parseTable = (text) => {
-  const regex = /<table>(.*?)<\/table>/g;
-  let parsedText = text.replace(regex, (match) => {
-    return `<table style="border-collapse: collapse; width: 100%;">${match}</table>`;
-  });
+  // 표를 처리하는 함수
+  const parseTable = (text) => {
+    const regex = /<table>(.*?)<\/table>/g;
+    let parsedText = text.replace(regex, (match) => {
+      return `<table style="border-collapse: collapse; width: 100%;">${match}</table>`;
+    });
 
-  parsedText = parsedText.replace(/<thead>/g, '<thead style="background-color: #f2f2f2;">');
-  parsedText = parsedText.replace(/<th>/g, '<th style="border: 1px solid #ddd; padding: 8px;">');
-  parsedText = parsedText.replace(/<td>/g, '<td style="border: 1px solid #ddd; padding: 8px;">');
+    parsedText = parsedText.replace(/<thead>/g, '<thead style="background-color: #f2f2f2;">');
+    parsedText = parsedText.replace(/<th>/g, '<th style="border: 1px solid #ddd; padding: 8px;">');
+    parsedText = parsedText.replace(/<td>/g, '<td style="border: 1px solid #ddd; padding: 8px;">');
 
-  return parsedText;
-};
+    return parsedText;
+  };
 
-// <br> 태그를 처리하는 함수
-const parseLineBreaks = (text) => {
-  const regex = /<br\s*\/?>/gi; 
-  const parsedText = text.replace(regex, '<br />');
-  return parsedText;
-};
+  // <br> 태그를 처리하는 함수
+  const parseLineBreaks = (text) => {
+    const regex = /<br\s*\/?>/gi;
+    const parsedText = text.replace(regex, '<br />');
+    return parsedText;
+  };
 
   // <content> 태그를 처리하는 함수
   const parseContent = (text) => {
@@ -66,19 +66,19 @@ const parseLineBreaks = (text) => {
     return parsedText;
   };
 
-// <longLine> 태그를 처리하는 함수
-const parseLongLine = (text) => {
-  const regex = /<longLine>/g; 
-  const parsedText = text.replace(regex, '<span style="display: inline-block; width: 120px; border-bottom: 1px solid black;"></span>');
-  return parsedText;
-};
+  // <longLine> 태그를 처리하는 함수
+  const parseLongLine = (text) => {
+    const regex = /<longLine>/g;
+    const parsedText = text.replace(regex, '<span style="display: inline-block; width: 120px; border-bottom: 1px solid black;"></span>');
+    return parsedText;
+  };
 
-// <longlongLine> 태그를 처리하는 함수
-const parseLongLongLine = (text) => {
-  const regex = /<longlongLine>/g; 
-  const parsedText = text.replace(regex, '<span style="display: inline-block; width: 250px; border-bottom: 1px solid black;"></span>');
-  return parsedText;
-};
+  // <longlongLine> 태그를 처리하는 함수
+  const parseLongLongLine = (text) => {
+    const regex = /<longlongLine>/g;
+    const parsedText = text.replace(regex, '<span style="display: inline-block; width: 250px; border-bottom: 1px solid black;"></span>');
+    return parsedText;
+  };
 
 
 
@@ -92,7 +92,7 @@ const parseLongLongLine = (text) => {
             {questionData.options.map((option, optionIndex) => (
               <li key={optionIndex}>{parse(parseHeaders(parseTable(parseLongLine(parseLongLongLine(parseContent(option))))))}</li>
             ))}
-          </ul> <br/>
+          </ul> <br />
         </div>
       ))}
     </div>


### PR DESCRIPTION
- [x]  에디터를 삭제하는 외부 컴포넌트 버튼과 내부 컴포넌트 버튼과 연결 시킬 방법을 알아본다.
     - 디자이너와 논의 후 결정 할 예정
- [x]  에디터를 생성한다.
- [x]  에디터를 삭제한다.
- [x]  문제 정답 등록을 구현을 논의 및 구상해본다.
- [x]  선택지 등록 블록에 선택지 특수 문자 숫자를 미리 생성 할 수 있게 구현 한다.
- [x] 전반적인 코드를 살피고 Routes관련 링크들을 수정 한다.

## 문제와 해결
- 에디터를 생성하고 삭제하는 부분은 어렵지 않았다. 다만 에디터를 생성하고 새로운 에디터를 생성할 때 역으로 새로운 배열을 생성해서 새로운 템플릿이 상단에 고정되게 만들면 내가 만든 문제가 리셋되는 부분이 있었다. 이에 대한 문제는 내가 받아온 데이터가 내부 컴포넌트에서 관리 되고 있기 때문이다. 이를 방지하기 위해서 다른 대안이 필요하며 상태 변수를 전역으로 관리할 수 있는 Recoil도입과 useState를 관리할 수 있는 컴포넌트를 따로 생성할지 고민하고 있다. 이에 관해 부분 별로 테스트를 진행 하고 있다.
- 문제 정답을 저장, 생성하는 방법은 문제 생성 바로 아래에 이루어지지 않고 문제 생성과 해답 생성 영역을 스위치로 바꿔가며 환경을 달리 만드는 방법으로 디자인과 논의가 이루어 졌다.
- 선택지라는 영역의 정체성을 뚜렷하게 보였으면 좋겠다는 디자인의 의견에 따라 선택지 영역에는 처음부터 특수 기호 숫자(ex.①)들이 바로 생성되게 구현을 하였다. 현재 이미지 부분도 이와 같이 이미지 영역만의 역할을 할 수 있게 구현 해달라는 의견을 반영하기 위해 코드를 테스하고 있다.
- exam_id가 존재하지 않아 400 Bad Request를 받았지만 스웨거를 통해 exam_id를 생성하고 서버와의 통신을 확인 했다.

## 결론
통상적인 테스트 코드는 아니지만 구현을 위한 테스트 코드들을 적극적으로 활용하며 디자인과 소통하고 있다. 

- close #82 