### PR TITLE
[BE] Feature AI 문제 생성을 할 수 있다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,11 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
 }
 
 ext {
-    set('snippetsDir', file("build/generated-snippets"))
+    set('springAiVersion', "0.8.1")
 }
 
 dependencies {
@@ -67,6 +68,15 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers:1.19.3'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation("org.testcontainers:junit-jupiter:1.12.0")
+
+    //Spring openai
+    implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/capstone/examlab/ai/AiService.java
+++ b/src/main/java/capstone/examlab/ai/AiService.java
@@ -1,0 +1,8 @@
+package capstone.examlab.ai;
+
+import capstone.examlab.ai.dto.Questions;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public interface AiService {
+    public Questions generateQuestions(String content) throws JsonProcessingException;
+}

--- a/src/main/java/capstone/examlab/ai/AiServiceImpl.java
+++ b/src/main/java/capstone/examlab/ai/AiServiceImpl.java
@@ -1,0 +1,51 @@
+package capstone.examlab.ai;
+
+import capstone.examlab.ai.dto.Questions;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.ChatClient;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AiServiceImpl implements AiService {
+
+    private final ChatClient chatClient;
+
+    private final ObjectMapper objectMapper;
+
+    private static final String PRE_STATEMENT = "public class Question {\n" +
+            "    // 문제\n" +
+            "    private String question;\n" +
+            "    \n" +
+            "    // 보기\n" +
+            "    private List<String> options;\n" +
+            "    \n" +
+            "    // 정답\n" +
+            "    private List<Integer> answers;\n" +
+            "    \n" +
+            "    // 해설\n" +
+            "    private String commentary;\n" +
+            "}\n" +
+            "아래 내용을 참고해서 한국어로 시험문제를 만들어줘.\n" +
+            "Question 객체에 파싱될 수 있는 json 형태로 5개를 배열로 만들어줘.\n\n";
+
+    private static final OpenAiChatOptions options = OpenAiChatOptions.builder()
+            .withModel("gpt-4-turbo")
+            .withResponseFormat(new OpenAiApi.ChatCompletionRequest.ResponseFormat("json_object"))
+            .build();
+
+    @Override
+    public Questions generateQuestions(String content) throws JsonProcessingException {
+        ChatResponse response = chatClient.call(
+                new Prompt(PRE_STATEMENT + content, options)
+        );
+        Questions questions = objectMapper.readValue(response.getResult().getOutput().getContent(), Questions.class);
+        return questions;
+    }
+}

--- a/src/main/java/capstone/examlab/ai/dto/Question.java
+++ b/src/main/java/capstone/examlab/ai/dto/Question.java
@@ -1,0 +1,32 @@
+package capstone.examlab.ai.dto;
+
+import capstone.examlab.questions.dto.update.QuestionUpdateDto;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class Question {
+    // 문제
+    private String question;
+
+    // 보기
+    private List<String> options;
+
+    // 정답
+    private List<Integer> answers;
+
+    // 해설
+    private String commentary;
+
+    public static QuestionUpdateDto toQuestionUpdateDto(Question question) {
+        return QuestionUpdateDto.builder()
+                .question(question.getQuestion())
+                .options(question.getOptions())
+                .answers(question.getAnswers())
+                .commentary(question.getCommentary())
+                .build();
+    }
+}

--- a/src/main/java/capstone/examlab/ai/dto/Questions.java
+++ b/src/main/java/capstone/examlab/ai/dto/Questions.java
@@ -1,0 +1,10 @@
+package capstone.examlab.ai.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class Questions {
+    List<Question> questions;
+}

--- a/src/main/java/capstone/examlab/exams/controller/ExamsController.java
+++ b/src/main/java/capstone/examlab/exams/controller/ExamsController.java
@@ -136,11 +136,6 @@ public class ExamsController {
         // TODO: AI 서비스 연동
         QuestionsListDto questionsListDto = examsService.getAiQuestions(examId, user);
 
-        // 임시로 활용
-        QuestionsSearchDto questionsSearchDto = QuestionsSearchDto.builder().count(5).build();
-        questionsListDto = questionsService.searchFromQuestions(1L, questionsSearchDto);
-
-
         return questionsListDto;
     }
 }

--- a/src/main/java/capstone/examlab/exams/domain/Exam.java
+++ b/src/main/java/capstone/examlab/exams/domain/Exam.java
@@ -35,4 +35,6 @@ public abstract class Exam {
     abstract public void setFile(String fileTitle, String fileText);
 
     abstract public void deleteFile();
+
+    abstract public String getFileText();
 }

--- a/src/main/java/capstone/examlab/exams/domain/ExamEntity.java
+++ b/src/main/java/capstone/examlab/exams/domain/ExamEntity.java
@@ -78,7 +78,6 @@ public class ExamEntity extends Exam {
     @Setter(AccessLevel.NONE) // 이 필드에 대한 setter는 생성하지 않음
     private String fileTitle;
 
-    @Getter(AccessLevel.NONE) // 이 필드에 대한 getter는 생성하지 않음
     @Setter(AccessLevel.NONE) // 이 필드에 대한 setter는 생성하지 않음
     private String fileText;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,6 @@ server.servlet.session.timeout=1800
 #limit multipart data size
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=100MB
+
+# Tomcat connection pool
+spring.datasource.tomcat.max-wait=100000


### PR DESCRIPTION
## 변경사항
- AI 서비스 도입
- 타임아웃 10초로 설정

## 배경
- chatGPT api를 활용한 문제 생성 기능이 필요했습니다.

## 테스트 방법
- 스웨거 테스트

## 궁금한점
- 코드에 comment와 함께 설명 적어두겠습니다.
- 추가적으로 `application-secrets.properties` 에 `spring.ai.openai.api-key` 값을 추가해야합니다.

close #97     