### PR TITLE
[BE] Feature: PDF파일 문자열로 변환 및 AI 문제 생성 로직에 제공

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     //Thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
+    //pdfbox
+    implementation 'org.apache.pdfbox:pdfbox:2.0.24'
+
     //Elasticsearch TestContainer
     testImplementation 'org.testcontainers:elasticsearch:1.19.3'
     testImplementation 'org.testcontainers:testcontainers:1.19.3'

--- a/src/main/java/capstone/examlab/exams/controller/ExamsController.java
+++ b/src/main/java/capstone/examlab/exams/controller/ExamsController.java
@@ -19,8 +19,10 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import java.io.File;
 import java.io.IOException;
-
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
+++ b/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
@@ -238,8 +238,15 @@ public class ExamServiceImpl implements ExamsService {
     }
 
     private void validateFileText(String fileText) throws BadRequestException {
-        if (fileText == null || fileText.trim().isEmpty() || fileText.length()<20) {
-            throw new BadRequestException("생성에 필요한 파일의 글자수가 부족합니다.");
+        if (fileText == null || fileText.trim().isEmpty()) {
+            throw new BadRequestException("생성에 필요한 파일의 내용이 없습니다.");
+        }
+
+        String[] words = fileText.split("\\s+");
+        int wordCount = words.length;
+
+        if (wordCount < 20) {
+            throw new BadRequestException("생성에 필요한 파일의 단어 수가 부족합니다.");
         }
     }
 }

--- a/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
+++ b/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
@@ -7,6 +7,7 @@ import capstone.examlab.exams.domain.Exam;
 import capstone.examlab.exams.dto.*;
 import capstone.examlab.exams.repository.ExamRepository;
 import capstone.examlab.exhandler.exception.UnauthorizedException;
+import capstone.examlab.pdf.PDFService;
 import capstone.examlab.questions.dto.QuestionsListDto;
 import capstone.examlab.questions.service.QuestionsService;
 import capstone.examlab.users.domain.User;
@@ -32,6 +33,7 @@ public class ExamServiceImpl implements ExamsService {
 
     private final ObjectProvider<Exam> examProvider;
     private final ExamRepository examRepository;
+    private final PDFService pdfService;
     private final QuestionsService questionsService;
     private final AiService aiService;
 
@@ -229,7 +231,7 @@ public class ExamServiceImpl implements ExamsService {
         }
         else if (fileType.equals("application/pdf")) {
             // TODO: pdf 파일을 text로 변환하는 로직
-
+            return pdfService.getTextFromPDF(file);
         }
         return null;
     }

--- a/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
+++ b/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
@@ -179,6 +179,8 @@ public class ExamServiceImpl implements ExamsService {
 
         String fileTitle = file.getOriginalFilename();
         String fileText = getFieldText(file, fileType);
+        //글자 수 유효검증
+        validateFileText(fileText);
 
         exam.setFile(fileTitle, fileText);
         examRepository.save(exam);
@@ -230,9 +232,14 @@ public class ExamServiceImpl implements ExamsService {
             }
         }
         else if (fileType.equals("application/pdf")) {
-            // TODO: pdf 파일을 text로 변환하는 로직
             return pdfService.getTextFromPDF(file);
         }
         return null;
+    }
+
+    private void validateFileText(String fileText) throws BadRequestException {
+        if (fileText == null || fileText.trim().isEmpty() || fileText.length()<20) {
+            throw new BadRequestException("생성에 필요한 파일의 글자수가 부족합니다.");
+        }
     }
 }

--- a/src/main/java/capstone/examlab/pdf/PDFService.java
+++ b/src/main/java/capstone/examlab/pdf/PDFService.java
@@ -1,0 +1,7 @@
+package capstone.examlab.pdf;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface PDFService {
+    String getTextFromPDF(MultipartFile pdfFile);
+}

--- a/src/main/java/capstone/examlab/pdf/PDFServiceImpl.java
+++ b/src/main/java/capstone/examlab/pdf/PDFServiceImpl.java
@@ -1,0 +1,27 @@
+package capstone.examlab.pdf;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PDFServiceImpl implements PDFService {
+    @Override
+    public String getTextFromPDF(MultipartFile pdfFile) {
+        try (PDDocument document = PDDocument.load(pdfFile.getInputStream())){
+            PDFTextStripper textStripper = new PDFTextStripper();
+            return textStripper.getText(document);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
+++ b/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
@@ -328,7 +328,8 @@ class ExamControllerOasTest extends RestDocsOpenApiSpecTest {
 
     @Test
     void testPostFile() throws Exception {
-        MockMultipartFile file = new MockMultipartFile("file", "강의자료.txt", "text/plain", "강의자료 내용입니다. 이 내용을 토대로 문제를 만들어야합니다.".getBytes());
+        MockMultipartFile file = new MockMultipartFile("file", "강의자료.txt", "text/plain", ("강의자료 내용입니다. 이 내용을 토대로 문제를 만들어야합니다. 하지만 자료의 내용은" +
+                "20단어를 넘겨야 문제를 생성 할 수 있어요. 그러니 꼭 20개 단어를 넘기는지 확인해 보세요").getBytes());
         //존재하지않는 RequestBuilder를 생성하기 위한 과정
         MockMultipartHttpServletRequestBuilder customRestDocumentationRequestBuilder =
                 RestDocumentationRequestBuilders.multipart("/api/v1/exams/{examId}/file", addExamsAndGetId());

--- a/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
+++ b/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
@@ -129,7 +129,7 @@ class ExamControllerOasTest extends RestDocsOpenApiSpecTest {
                 .andExpect(status().isOk())
                 .andDo(document("delete-exams",
                         resource(ResourceSnippetParameters.builder()
-                                .description("본인의 시험만 삭제할 수 있습니다")
+                                .description("본인의 시험만 삭제할 수 있습니다 또한 관련된 문제들도 삭제 됩니다")
                                 .tag("exams")
                                 .summary("delete exams")
                                 .build()

--- a/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
+++ b/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
@@ -287,7 +287,7 @@ class ExamControllerOasTest extends RestDocsOpenApiSpecTest {
 
     @Test
     void testPostFile() throws Exception {
-        MockMultipartFile file = new MockMultipartFile("file", "강의자료.txt", "text/plain", "강의자료 내용입니다.".getBytes());
+        MockMultipartFile file = new MockMultipartFile("file", "강의자료.txt", "text/plain", "강의자료 내용입니다. 이 내용을 토대로 문제를 만들어야합니다.".getBytes());
         //존재하지않는 RequestBuilder를 생성하기 위한 과정
         MockMultipartHttpServletRequestBuilder customRestDocumentationRequestBuilder =
                 RestDocumentationRequestBuilders.multipart("/api/v1/exams/{examId}/file", addExamsAndGetId());

--- a/src/test/java/capstone/examlab/questions/controller/QuestionsControllerOasTest.java
+++ b/src/test/java/capstone/examlab/questions/controller/QuestionsControllerOasTest.java
@@ -215,7 +215,7 @@ class QuestionsControllerOasTest extends RestDocsOpenApiSpecTest {
                 .andDo(document("add-questions",
                         resource(ResourceSnippetParameters.builder()
                                 .description("문제 추가")
-                                .tag("question")
+                                .tag("questions")
                                 .summary("Add question")
                                 .requestHeaders(HeaderDocumentation.headerWithName(HttpHeaders.CONTENT_TYPE)
                                         .description("questionUploadInfo-ContentType: application/json" +
@@ -242,7 +242,7 @@ class QuestionsControllerOasTest extends RestDocsOpenApiSpecTest {
                 .andDo(document("Search-questions",
                         resource(ResourceSnippetParameters.builder()
                                 .description("Exam ID를 통한 Questions 조회")
-                                .tag("question")
+                                .tag("questions")
                                 .summary("Search questions")
                                 .pathParameters(
                                         parameterWithName("examId").description("ExamId").type(SimpleType.INTEGER)
@@ -309,7 +309,7 @@ class QuestionsControllerOasTest extends RestDocsOpenApiSpecTest {
                 .andDo(document("update-question",
                         resource(ResourceSnippetParameters.builder()
                                 .description("Question 내용 업데이트")
-                                .tag("question")
+                                .tag("questions")
                                 .summary("Update question")
                                 .requestFields(
                                         fieldWithPath("id").description("문제 ID").type(JsonFieldType.STRING),
@@ -337,7 +337,7 @@ class QuestionsControllerOasTest extends RestDocsOpenApiSpecTest {
 //                .andDo(document("delete-questions-by-examId",
 //                        resource(ResourceSnippetParameters.builder()
 //                                .description("해당되는 시험 ID Questions 삭제")
-//                                .tag("question")
+//                                .tag("questions")
 //                                .summary("Delete questions by examId")
 //                                .pathParameters(
 //                                        parameterWithName("examId").description("ExamId").type(SimpleType.INTEGER)
@@ -356,7 +356,7 @@ class QuestionsControllerOasTest extends RestDocsOpenApiSpecTest {
                 .andDo(document("delete-questions-by-questionId",
                         resource(ResourceSnippetParameters.builder()
                                 .description("해당되는 문제 ID Question 삭제")
-                                .tag("question")
+                                .tag("questions")
                                 .summary("Delete questions by questionId")
                                 .pathParameters(
                                         parameterWithName("questionId").description("QuestionId").type(SimpleType.STRING)


### PR DESCRIPTION
## 변경사항
- pdf -> text 변환 서비스 로직 생성 
- 생성한 로직 ai문제 생성으로 코드 합치기 및 테스트

## 배경
- txt, md파일과 다르게 pdf파일은 text로 변환하는 라이브러리 및 코드가 필요했습니다

## 테스트 방법
- src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java

## 궁금한점
- 변환 코드가 들어갈 pdfService생성 및 examService에서 참조하도록 했습니다


close #96   