### PR TITLE
BE] Fix: Question 검색 조건에 같은 속성 여러개의 태그 적용이 안되는 버그 수정

### DIFF
--- a/src/main/java/capstone/examlab/questions/service/QuestionsService.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsService.java
@@ -26,4 +26,6 @@ public interface QuestionsService {
     void deleteQuestionsByExamId(Long examId);
 
     void deleteQuestionsByQuestionId(User user, String questionId);
+
+    int countQuestionsByExamId(Long examId);
 }

--- a/src/main/java/capstone/examlab/questions/service/QuestionsServiceImpl.java
+++ b/src/main/java/capstone/examlab/questions/service/QuestionsServiceImpl.java
@@ -10,6 +10,9 @@ import capstone.examlab.questions.documnet.Question;
 import capstone.examlab.questions.repository.BoolQueryBuilder;
 import capstone.examlab.questions.repository.QuestionsRepository;
 import capstone.examlab.users.domain.User;
+import co.elastic.clients.elasticsearch._types.aggregations.AggregationBuilders;
+import co.elastic.clients.elasticsearch._types.aggregations.TermsAggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.ValueCountAggregation;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -111,6 +114,11 @@ public class QuestionsServiceImpl implements QuestionsService {
 
     @Override
     public void deleteQuestionsByQuestionId(User user, String questionId) {questionsRepository.deleteById(questionId);}
+
+    @Override
+    public int countQuestionsByExamId(Long examId) {
+        return questionsRepository.findByExamId(examId).size();
+    }
 
     //이미지 생성 및 url추가 로직
     private void processImages(List<MultipartFile> images, QuestionUploadInfo questionUploadInfo, String imageType) {

--- a/src/test/java/capstone/examlab/questions/repository/QuestionsRepositoryTest.java
+++ b/src/test/java/capstone/examlab/questions/repository/QuestionsRepositoryTest.java
@@ -175,4 +175,9 @@ public class QuestionsRepositoryTest {
         questionsRepository.deleteById(questionUuid);
         assertThat(questionsRepository.existsById(questionUuid)).isFalse();
     }
+
+    @Test
+    void countQuestionsByExamId(){
+        assertThat(questionsRepository.findByExamId(existExamId).size() == 1);
+    }
 }


### PR DESCRIPTION
## 변경사항
- 검색 조건으로 같은 속성에 여러개의 태그를 적용하는 과정에서 생긴 에러 해결
- 시험 문제 개수를 반환하는 메서드 생성

## 배경
- 한 속성에 여러개의 태그가 적용되도록 에러 수정해야 합니다
- 시험에 해당하는 문제의 개수를 보여줄 메서드가 필요했습니다

## 테스트 방법
- src/test/java/capstone/examlab/questions/repository/QuestionsRepositoryTest.java
 
## 궁금한점
- 집계 쿼리 관련해서는 학습 후 적용 예정입니다. 임시로 가져온 데이터의 size()를 토대로 개수를 반환하도록 했습니다

close #117      