### PR TITLE
[BE] Feature: 시험 태그는 단어만 가능하고, 시험리스트에서 문제 개수도 반환한다

### DIFF
--- a/src/main/java/capstone/examlab/exams/controller/ExamsController.java
+++ b/src/main/java/capstone/examlab/exams/controller/ExamsController.java
@@ -9,6 +9,7 @@ import capstone.examlab.questions.dto.search.QuestionsSearchDto;
 import capstone.examlab.questions.service.QuestionsService;
 import capstone.examlab.users.argumentresolver.Login;
 import capstone.examlab.users.domain.User;
+import capstone.examlab.util.Util;
 import capstone.examlab.valid.ValidExamId;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -57,7 +59,14 @@ public class ExamsController {
     @PostMapping
     public ResponseDto createExam(
             @Login User user,
-            @Validated @RequestBody ExamAddDto examAddDto) {
+            @Validated @RequestBody ExamAddDto examAddDto) throws BadRequestException {
+
+        for (List<String> tags : examAddDto.getTags().values()) {
+            for (String tag : tags) {
+                if (!Util.isSingleToken(tag))
+                    throw new BadRequestException("태그는 공백 없이 한 단어로 입력해주세요.");
+            }
+        }
 
         // AOP 도입 예정
         if (user == null) {
@@ -85,7 +94,14 @@ public class ExamsController {
     public ResponseDto updateExam(
             @Login User user,
             @PathVariable @ValidExamId Long examId,
-            @Validated @RequestBody ExamUpdateDto examUpdateDto) {
+            @Validated @RequestBody ExamUpdateDto examUpdateDto) throws BadRequestException {
+
+        for (List<String> tags : examUpdateDto.getTags().values()) {
+            for (String tag : tags) {
+                if (!Util.isSingleToken(tag))
+                    throw new BadRequestException("태그는 공백 없이 한 단어로 입력해주세요.");
+            }
+        }
 
         // AOP 도입 예정
         if (user == null) {

--- a/src/main/java/capstone/examlab/exams/dto/ExamDto.java
+++ b/src/main/java/capstone/examlab/exams/dto/ExamDto.java
@@ -9,4 +9,5 @@ import lombok.Data;
 public class ExamDto {
     private String examTitle;
     private Long examId;
+    private Integer size;
 }

--- a/src/main/java/capstone/examlab/exams/runner/ExamDatabaseInitializer.java
+++ b/src/main/java/capstone/examlab/exams/runner/ExamDatabaseInitializer.java
@@ -3,6 +3,7 @@ package capstone.examlab.exams.runner;
 import capstone.examlab.exams.domain.Exam;
 import capstone.examlab.exams.repository.ExamRepository;
 import capstone.examlab.users.domain.User;
+import capstone.examlab.users.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
@@ -22,7 +23,9 @@ public class ExamDatabaseInitializer implements ApplicationRunner {
 
     private final ObjectProvider<Exam> examProvider;
     private final ExamRepository examRepository;
-//    private final SubExamRepository subExamRepository;
+    // 개발용 코드
+//    private final UserRepository userRepository;
+
     @Override
     public void run(ApplicationArguments args) {
         // 데이터 베이스 초기화
@@ -41,7 +44,15 @@ public class ExamDatabaseInitializer implements ApplicationRunner {
 
         Exam englishSATExam = examProvider.getObject();
         englishSATExam.setExamTitle("수능 - 영어");
-        englishSATExam.setTypes(Map.of("category", List.of("문법", "독해", "어휘", "듣기")));
+        englishSATExam.setTypes(Map.of(
+                "연도", List.of("2024", "2023", "2022"),
+                "월", List.of("6", "9", "11"),
+                "분류", List.of("목적", "분위기심경", "대의파악", "함의추론", "도표이해", "내용일치", "실용문일치", "어법", "단어쓰임", "빈칸추론", "무관한문장", "글의순서", "문장넣기", "요약문완성"),
+                "배점", List.of("2", "3")));
+
+        // 개발용 코드
+//        User user = (User) userRepository.findByUserId("lab3@gmail.com").get();
+//        englishSATExam.setUser(user);
 
         try {
             englishSATExam = examRepository.save(englishSATExam);

--- a/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
+++ b/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
@@ -84,8 +84,7 @@ public class ExamServiceImpl implements ExamsService {
                     examList.add(ExamDto.builder()
                             .examTitle(((Exam)exam).getExamTitle())
                             .examId(((Exam)exam).getExamId())
-                            // TODO: size 계산
-                            .size(1234)
+                            .size(questionsService.countQuestionsByExamId(((Exam)exam).getExamId()))
                             .build());
                 });
         return examList;

--- a/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
+++ b/src/main/java/capstone/examlab/exams/service/ExamServiceImpl.java
@@ -84,6 +84,8 @@ public class ExamServiceImpl implements ExamsService {
                     examList.add(ExamDto.builder()
                             .examTitle(((Exam)exam).getExamTitle())
                             .examId(((Exam)exam).getExamId())
+                            // TODO: size 계산
+                            .size(1234)
                             .build());
                 });
         return examList;

--- a/src/main/java/capstone/examlab/util/Util.java
+++ b/src/main/java/capstone/examlab/util/Util.java
@@ -1,0 +1,11 @@
+package capstone.examlab.util;
+
+public final class Util {
+
+    private Util() {}
+
+    public static boolean isSingleToken(String str) {
+        if (!str.matches("^[a-zA-z가-힣0-9]+$")) throw new IllegalArgumentException("Invalid token");
+        return str.trim().split("\\s+").length == 1;
+    }
+}

--- a/src/main/java/capstone/examlab/util/Util.java
+++ b/src/main/java/capstone/examlab/util/Util.java
@@ -5,7 +5,7 @@ public final class Util {
     private Util() {}
 
     public static boolean isSingleToken(String str) {
-        if (!str.matches("^[a-zA-z가-힣0-9]+$")) throw new IllegalArgumentException("Invalid token");
-        return str.trim().split("\\s+").length == 1;
+        if (!str.matches("^[a-zA-z가-힣0-9]+$")) return false;
+        return true;
     }
 }

--- a/src/main/resources/static/api/v1/openapi3.yaml
+++ b/src/main/resources/static/api/v1/openapi3.yaml
@@ -32,7 +32,8 @@ paths:
               examples:
                 exams:
                   value: "{\"exams\":[{\"exam_title\":\"운전면허 - 1,2종\",\"exam_id\"\
-                    :1},{\"exam_title\":\"수능 - 영어\",\"exam_id\":2}]}"
+                    :1,\"size\":1234},{\"exam_title\":\"수능 - 영어\",\"exam_id\":2,\"\
+                    size\":1234}]}"
     post:
       tags:
       - exams
@@ -73,7 +74,7 @@ paths:
             examples:
               update-question:
                 value: "{\"question\":\"변경된 질문입니다.\",\"options\":[\"변경된 보기1\",\"변경\
-                  된 보기2\",\"변경된 보기3\",\"변경된 보기4\"],\"answers\":[1,3],\"id\":\"Aw5jV48BXRBYEYFcoMBf\"\
+                  된 보기2\",\"변경된 보기3\",\"변경된 보기4\"],\"answers\":[1,3],\"id\":\"KQ4vXY8BXRBYEYFcb8AO\"\
                   ,\"commentary\":\"변경된 설명입니다.\",\"tags\":{\"난이도\":[\"중\"],\"단원\"\
                   :[\"2\"]}}"
       responses:
@@ -82,7 +83,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
+                $ref: '#/components/schemas/api-v1-questions486549215'
               examples:
                 update-question:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -100,10 +101,10 @@ paths:
               $ref: '#/components/schemas/api-v1-users-963924044'
             examples:
               user add:
-                value: "{\"password\":\"1c75a40e-0ee9-4514-86da-1a55e0bd87ed!\",\"\
-                  password_confirm\":\"1c75a40e-0ee9-4514-86da-1a55e0bd87ed!\",\"\
-                  user_id\":\"1c75a40e-0ee9-4514-86da-1a55e0bd87ed@gmail.com\",\"\
-                  name\":\"1c75a40e-0ee9-4514-86da-1a55e0bd87ed\"}"
+                value: "{\"password\":\"6fe6f1bf-ba20-419c-b170-4898a5939f22!\",\"\
+                  password_confirm\":\"6fe6f1bf-ba20-419c-b170-4898a5939f22!\",\"\
+                  user_id\":\"6fe6f1bf-ba20-419c-b170-4898a5939f22@gmail.com\",\"\
+                  name\":\"6fe6f1bf-ba20-419c-b170-4898a5939f22\"}"
       responses:
         "200":
           description: "200"
@@ -153,7 +154,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
+              $ref: '#/components/schemas/api-v1-questions486549215'
             examples:
               patch-exams:
                 value: "{\"tags\":{\"난이도\":[\"상\",\"중\",\"하\",\"최하\"],\"단원\":[\"1\"\
@@ -164,7 +165,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
+                $ref: '#/components/schemas/api-v1-questions486549215'
               examples:
                 patch-exams:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -187,7 +188,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
+                $ref: '#/components/schemas/api-v1-questions486549215'
               examples:
                 delete-exams:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -211,7 +212,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
+                $ref: '#/components/schemas/api-v1-questions486549215'
               examples:
                 delete-questions-by-questionId:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -338,7 +339,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
+                $ref: '#/components/schemas/api-v1-questions486549215'
               examples:
                 post-file:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -364,7 +365,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
+                $ref: '#/components/schemas/api-v1-questions486549215'
               examples:
                 delete-exam-file:
                   value: "{\"code\":200,\"message\":\"OK\"}"
@@ -417,7 +418,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-exams-examId-questions-1876066633'
               examples:
                 Search-questions:
-                  value: "{\"questions\":[{\"id\":\"BA5jV48BXRBYEYFcocBC\",\"type\"\
+                  value: "{\"questions\":[{\"id\":\"Kg4vXY8BXRBYEYFcb8Dm\",\"type\"\
                     :\"객관식\",\"question\":\"소웨공 테스트 문제?\",\"question_images_in\":[],\"\
                     question_images_out\":[],\"options\":[\"① 답 예시 1\",\"② 답 예시 2\"\
                     ,\"③ 답 예시 3\",\"④ 답 예시 4\"],\"answers\":[3],\"commentary\":\"\
@@ -454,23 +455,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-exams-examId-file486549215'
+                $ref: '#/components/schemas/api-v1-questions486549215'
               examples:
                 add-questions:
-                  value: "{\"code\":201,\"message\":{\"id\":\"Ag5jV48BXRBYEYFcn8Cy\"\
+                  value: "{\"code\":201,\"message\":{\"id\":\"KA4vXY8BXRBYEYFcbsBt\"\
                     ,\"type\":\"객관식\",\"question\":\"다음 중 총중량 1.5톤 피견인 승용자동차를 4.5톤\
                     \ 화물자동차로 견인하는 경우 필요한 운전면허에 해당하지 않은 것은?\",\"question_images_in\"\
-                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/4c10bb0c-d175-4f52-8449-c203623f6af0.png\"\
+                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/11cdf3cb-3f7e-4936-9182-4e6cd72fc50f.png\"\
                     ,\"description\":\"설명1\",\"attribute\":\"속성1\"}],\"question_images_out\"\
-                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/786eaa44-1789-409d-a6e0-2b04d1bda18e.png\"\
+                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/fafede70-2bcf-45ac-b96c-cb0c949c93ef.png\"\
                     ,\"description\":\"설명2\",\"attribute\":\"속성2\"}],\"options\":[\"\
                     ① 제1종 대형면허 및 소형견인차면허\",\"② 제1종 보통면허 및 대형견인차면허\",\"③ 제1종 보통면허 및\
                     \ 소형견인차면허\",\"④ 제2종 보통면허 및 대형견인차면허\"],\"answers\":[4],\"commentary\"\
                     :\"도로교통법 시행규칙 별표18 총중량 750킬로그램을 초과하는 3톤 이하의 피견인 자동차를 견인하기 위해서는\
                     \ 견인 하는 자동차를 운전할 수 있는 면허와 소형견인차면허 또는 대형견인차면허를 가지고 있어야 한다.\",\"\
-                    commentary_images_in\":[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/97017213-ee5e-4f83-89b0-8fb002ee0c5a.png\"\
+                    commentary_images_in\":[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/acc08858-f2ec-4e23-bd83-3c926b97f277.png\"\
                     ,\"description\":\"설명3\",\"attribute\":\"속성3\"}],\"commentary_images_out\"\
-                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/0c189bb8-dc14-4a37-97a5-71ef0144abad.png\"\
+                    :[{\"url\":\"https://examlab-image.s3.ap-northeast-2.amazonaws.com/test_images/3fdeb245-1de2-40c5-8db1-c6bbc2370d62.png\"\
                     ,\"description\":\"설명4\",\"attribute\":\"속성4\"}],\"tags\":{}}}"
 components:
   schemas:
@@ -540,27 +541,6 @@ components:
     ExamType:
       title: ExamType
       type: object
-    ExamList:
-      title: ExamList
-      required:
-      - exams
-      type: object
-      properties:
-        exams:
-          type: array
-          description: Exam
-          items:
-            required:
-            - exam_id
-            - exam_title
-            type: object
-            properties:
-              exam_id:
-                type: number
-                description: Exam id
-              exam_title:
-                type: string
-                description: Exam title
     api-v1-users-login1770795545:
       required:
       - password
@@ -573,6 +553,27 @@ components:
         user_id:
           type: string
           description: User id
+    ExamFile:
+      title: ExamFile
+      required:
+      - code
+      type: object
+      properties:
+        code:
+          type: number
+          description: 응답 코드
+        message:
+          required:
+          - exist
+          - file_title
+          type: object
+          properties:
+            exist:
+              type: boolean
+              description: 파일 존재 여부
+            file_title:
+              type: string
+              description: File title
     api-v1-exams-examId-questions-1876066633:
       required:
       - questions
@@ -716,30 +717,34 @@ components:
                       - type: string
                       - type: number
                 description: 문제의 태그 맵 정보
-    ExamFile:
-      title: ExamFile
-      required:
-      - code
-      type: object
-      properties:
-        code:
-          type: number
-          description: 응답 코드
-        message:
-          required:
-          - exist
-          - file_title
-          type: object
-          properties:
-            exist:
-              type: boolean
-              description: 파일 존재 여부
-            file_title:
-              type: string
-              description: File title
     AiQuestions:
       title: AiQuestions
       type: object
+    ExamList:
+      title: ExamList
+      required:
+      - exams
+      type: object
+      properties:
+        exams:
+          type: array
+          description: Exam
+          items:
+            required:
+            - exam_id
+            - exam_title
+            - size
+            type: object
+            properties:
+              size:
+                type: number
+                description: Exam size
+              exam_id:
+                type: number
+                description: Exam id
+              exam_title:
+                type: string
+                description: Exam title
     ExamAdd:
       title: ExamAdd
       required:
@@ -753,6 +758,20 @@ components:
         exam_title:
           type: string
           description: 시험지 이름
+    api-v1-questions486549215:
+      type: object
+    api-v1-users-status615510992:
+      required:
+      - login
+      - user_name
+      type: object
+      properties:
+        user_name:
+          type: string
+          description: 사용자 이름
+        login:
+          type: boolean
+          description: 로그인 여부
     api-v1-users-963924044:
       required:
       - name
@@ -773,17 +792,3 @@ components:
         name:
           type: string
           description: User name
-    api-v1-users-status615510992:
-      required:
-      - login
-      - user_name
-      type: object
-      properties:
-        user_name:
-          type: string
-          description: 사용자 이름
-        login:
-          type: boolean
-          description: 로그인 여부
-    api-v1-exams-examId-file486549215:
-      type: object

--- a/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
+++ b/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
@@ -122,6 +122,8 @@ class ExamControllerOasTest extends RestDocsOpenApiSpecTest {
 
     @Test
     void deleteExams() throws Exception {
+        doNothing().when(questionsService).deleteQuestionsByExamId(anyLong());
+
         this.mockMvc.perform(
                         delete("/api/v1/exams/{examId}", addExamsAndGetId())
                                 .session(doLogin())
@@ -263,7 +265,6 @@ class ExamControllerOasTest extends RestDocsOpenApiSpecTest {
 
     @Test
     void testDeleteExamFile() throws Exception {
-        doNothing().when(questionsService).deleteQuestionsByExamId(anyLong());
         this.mockMvc.perform(delete("/api/v1/exams/{examId}/file", addExamsAndSetFileAndGetId())
                         .session(doLogin()))
                 .andExpect(status().isOk())

--- a/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
+++ b/src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java
@@ -188,7 +188,8 @@ class ExamControllerOasTest extends RestDocsOpenApiSpecTest {
                                                 .attributes(Attributes.key("exam_title").value(String.class),
                                                         Attributes.key("exam_id").value(Long.class)),
                                         fieldWithPath("exams[].exam_title").description("Exam title").type(JsonFieldType.STRING),
-                                        fieldWithPath("exams[].exam_id").description("Exam id").type(JsonFieldType.NUMBER)
+                                        fieldWithPath("exams[].exam_id").description("Exam id").type(JsonFieldType.NUMBER),
+                                        fieldWithPath("exams[].size").description("Exam size").type(JsonFieldType.NUMBER)
                                 )
                                 .responseSchema(Schema.schema("ExamList"))
                                 .build()


### PR DESCRIPTION
## 변경사항
- 시험리스트에서 문제 개수도 반환한다
- 시험 태그는 단어만 가능하다
- 영어 시험 태그 변환

## 배경
- 전체 검색시에도 검색, 태그를 통한 조건 검색이 가능해야 합니다

## 테스트 방법
- src/test/java/capstone/examlab/exams/controller/ExamControllerOasTest.java

## 궁금한점
- 토큰을 잘 카운트하기 까다롭습니다
- 토큰 전략이 엘라스틱 서치의 전략에 따르는데 한국어 또는 특수문자를 따지기 어렵지만, 현재는 태그값에 특수문제를 배제해서 해결했습니다

close #118 