### PR TITLE
[BE] Refactoring: 문재 갯수 제한 검증 추가 

### DIFF
--- a/src/main/java/capstone/examlab/valid/ParmasValidator.java
+++ b/src/main/java/capstone/examlab/valid/ParmasValidator.java
@@ -4,6 +4,7 @@ import capstone.examlab.util.Util;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.BadRequestException;
 import org.springframework.util.MultiValueMap;
 
 import java.util.List;
@@ -35,7 +36,10 @@ public class ParmasValidator implements ConstraintValidator<ValidParams, MultiVa
             }
             //value 검증
             for (String s: params.get(key)) {
-                if (!Util.isSingleToken(s)||s.length() > 20) {
+                if(key.equals("count")&&Integer.parseInt(s)>10000){
+                    return false;
+                }
+                else if (!Util.isSingleToken(s)||s.length() > 20) {
                     return false;
                 }
             }


### PR DESCRIPTION
## 변경사항
- 문재 갯수 검증 추가

## 배경
- Elasticsearch의 1개 요청에 조회 가능한 데이터가 default 1만개입니다. 따라서 1만개 초과되는 문제 갯수는 검증이 필요했습니다.

## 테스트 방법
- 간단한 내용이라서 Postman으로 테스트 및 badrequest반환 확인했습니다.

## 궁금한점
- 없습니다 

close #138  