### PR TITLE
[BE] Feature: AI 응답이 실패할 경우 재요청 #140

### DIFF
--- a/src/main/java/capstone/examlab/ai/dto/Questions.java
+++ b/src/main/java/capstone/examlab/ai/dto/Questions.java
@@ -1,10 +1,13 @@
 package capstone.examlab.ai.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
 public class Questions {
+
+    @NotNull
     List<Question> questions;
 }


### PR DESCRIPTION
## 변경사항
- AI 문제 생성 실패시 재요청 로직 추가

## 배경
- AI의 성능이 100 퍼센트가 아니라 실패할 경우 해결할 보완 로직이 필요했습니다

## 테스트 방법
- 아래 스크린샷으로 첨부하겠습니다.
- 아래와 같이 실패할 경우 다시 요청합니다
![image](https://github.com/LuizyHub/exam-lab/assets/104267255/bd0818e3-4777-4fbd-83ca-380a39298648)


## 궁금한점
- 없습니다 

close #140