### PR TITLE
[BE] Feature: 띄어쓰기 포함된 검색어 처리 가능하게 변경 #143

### DIFF
--- a/src/main/java/capstone/examlab/backoffice/inputdata/QuestionsDataController.java
+++ b/src/main/java/capstone/examlab/backoffice/inputdata/QuestionsDataController.java
@@ -24,4 +24,12 @@ public class QuestionsDataController {
         questionsDataService.saveQuestions(questions);
         return ResponseEntity.ok("data add success");
     }
+
+    @DeleteMapping("{examId}/questions")
+    public ResponseEntity<String> deleteOriginalQuestions(@PathVariable Long examId) {
+        if(examId == 2){
+//            questionsDataService.deleteQuestion(examId);
+        }
+        return ResponseEntity.ok("data delete success");
+    }
 }

--- a/src/main/java/capstone/examlab/backoffice/inputdata/QuestionsDataService.java
+++ b/src/main/java/capstone/examlab/backoffice/inputdata/QuestionsDataService.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface QuestionsDataService {
     void saveQuestions(List<Question> questionEntities);
+
+    void deleteQuestion(Long examId);
 }

--- a/src/main/java/capstone/examlab/backoffice/inputdata/QuestionsDataServiceImpl.java
+++ b/src/main/java/capstone/examlab/backoffice/inputdata/QuestionsDataServiceImpl.java
@@ -15,4 +15,9 @@ public class QuestionsDataServiceImpl implements QuestionsDataService{
     public void saveQuestions(List<Question> questions) {
         questionsRepository.saveAll(questions);
     }
+
+    @Override
+    public void deleteQuestion(Long examId) {
+        questionsRepository.deleteByExamId(examId);
+    }
 }

--- a/src/main/java/capstone/examlab/questions/dto/search/QuestionsSearchDto.java
+++ b/src/main/java/capstone/examlab/questions/dto/search/QuestionsSearchDto.java
@@ -5,10 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Data
 @Builder
@@ -31,7 +28,10 @@ public class QuestionsSearchDto {
                 String category = tokens[1];
                 tags.computeIfAbsent(category, k -> new ArrayList<>()).addAll(values);
             } else if (key.equals("includes")) {
-                includes.addAll(values);
+                for (String value : values) {
+                    String[] words = value.split(" ");
+                    includes.addAll(Arrays.asList(words));
+                }
             } else if (key.equals("count")) {
                 try {
                     count = Integer.parseInt(values.get(0));

--- a/src/main/java/capstone/examlab/valid/ParmasValidator.java
+++ b/src/main/java/capstone/examlab/valid/ParmasValidator.java
@@ -38,8 +38,14 @@ public class ParmasValidator implements ConstraintValidator<ValidParams, MultiVa
             for (String s: params.get(key)) {
                 if(key.equals("count")&&Integer.parseInt(s)>10000){
                     return false;
-                }
-                else if (!Util.isSingleToken(s)||s.length() > 20) {
+                } else if(key.equals("includes")||s.length() > 20){
+                    String[] words = s.split(" ");
+                    for (String word : words) {
+                        if (!Util.isSingleToken(word) || word.length() > 20) {
+                            return false;
+                        }
+                    }
+                } else if (!Util.isSingleToken(s)||s.length() > 20) {
                     return false;
                 }
             }

--- a/src/main/java/capstone/examlab/valid/ParmasValidator.java
+++ b/src/main/java/capstone/examlab/valid/ParmasValidator.java
@@ -4,15 +4,11 @@ import capstone.examlab.util.Util;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.coyote.BadRequestException;
 import org.springframework.util.MultiValueMap;
-
-import java.util.List;
-import java.util.Map;
 
 @Slf4j
 public class ParmasValidator implements ConstraintValidator<ValidParams, MultiValueMap<String, String>> {
-
+    private static final int MAX_SEARCH_PARAMETER_SIZE = 20;
     @Override
     public void initialize(ValidParams constraintAnnotation) {
     }
@@ -25,7 +21,7 @@ public class ParmasValidator implements ConstraintValidator<ValidParams, MultiVa
         for (String key : params.keySet()) {
             //key 검증
             if(key.contains("tags")){
-                if(!Util.matchesTagsPattern(key)||key.length() > 20) {
+                if(!Util.matchesTagsPattern(key)||key.length() > MAX_SEARCH_PARAMETER_SIZE) {
                     return false;
                 }
             }
@@ -38,14 +34,14 @@ public class ParmasValidator implements ConstraintValidator<ValidParams, MultiVa
             for (String s: params.get(key)) {
                 if(key.equals("count")&&Integer.parseInt(s)>10000){
                     return false;
-                } else if(key.equals("includes")||s.length() > 20){
+                } else if(key.equals("includes")||s.length() > MAX_SEARCH_PARAMETER_SIZE){
                     String[] words = s.split(" ");
                     for (String word : words) {
-                        if (!Util.isSingleToken(word) || word.length() > 20) {
+                        if (!Util.isSingleToken(word) || word.length() > MAX_SEARCH_PARAMETER_SIZE) {
                             return false;
                         }
                     }
-                } else if (!Util.isSingleToken(s)||s.length() > 20) {
+                } else if (!Util.isSingleToken(s)||s.length() > MAX_SEARCH_PARAMETER_SIZE) {
                     return false;
                 }
             }


### PR DESCRIPTION
## 변경사항
- 띄어쓰기 포함된 검색어 처리가능하게 Valid 변경 및 DTO데이터 전환 코드 변경

## 배경
- 사용자가 검색어를 띄어쓰기 포함하고 작성할 수 있게 변경해야했습니다. 

## 테스트 방법
- 아래와 같이 띄어쓰기(인코딩 규칙상 %20으로 대체)가 존재해도 잘 분리해서 찾아내는걸 확인 할 수 있습니다.
<img width="1033" alt="image" src="https://github.com/LuizyHub/exam-lab/assets/120697456/319b525a-a00e-46e7-8529-50415e684dfe">

## 궁금한점
- str.matches("^[a-zA-Z가-힣0-9]+( [a-zA-Z가-힣0-9]+)*$" 와 같이 정규식을 사용했을때 RegExr사이트 상에서는 문제가 없었지만 실제 코드에서는 통과되지 못했습니다. 따라서 paras value를 split해서 기존에 존재하던 정규식으로 검증 할 수 있게 두었습니다.
![image](https://github.com/LuizyHub/exam-lab/assets/120697456/8fd9721f-d331-4576-8930-840f5b0818b8)


close #143