### PR TITLE
[BE] Feature: 토큰 개수를 정확히 측정할 수 있다

### DIFF
--- a/src/main/java/capstone/examlab/token/TokenService.java
+++ b/src/main/java/capstone/examlab/token/TokenService.java
@@ -1,0 +1,6 @@
+package capstone.examlab.token;
+
+public interface TokenService {
+
+    int getTokenCount(String content);
+}

--- a/src/main/java/capstone/examlab/token/TokenServicePython.java
+++ b/src/main/java/capstone/examlab/token/TokenServicePython.java
@@ -1,0 +1,50 @@
+package capstone.examlab.token;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+@Service
+public class TokenServicePython implements TokenService{
+
+
+    @Override
+    public int getTokenCount(String content) {
+        int tokenCount = 0;
+        try {
+            // ClassPathResource를 사용하여 리소스 경로를 가져옵니다.
+            Resource resource = new ClassPathResource("scripts/token_count.py");
+
+            // 리소스를 임시 파일로 복사합니다.
+            Path tempScript = Files.createTempFile("token_count", ".py");
+            try (InputStream inputStream = resource.getInputStream()) {
+                Files.copy(inputStream, tempScript, StandardCopyOption.REPLACE_EXISTING);
+            }
+            // Python 실행 명령어와 인자를 설정합니다.
+            String[] command = new String[]{"python3", tempScript.toAbsolutePath().toString(), content};
+
+            // 프로세스 빌더를 생성하고 실행합니다.
+            ProcessBuilder processBuilder = new ProcessBuilder(command);
+            Process process = processBuilder.start();
+
+            // 프로세스의 출력을 읽어옵니다.
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                if ((line = reader.readLine()) != null) {
+                    tokenCount = Integer.parseInt(line);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return tokenCount;
+    }
+}

--- a/src/main/resources/scripts/token_count.py
+++ b/src/main/resources/scripts/token_count.py
@@ -1,0 +1,4 @@
+import sys
+import tiktoken
+
+print(len(tiktoken.encoding_for_model('gpt-4o').encode(sys.argv[1])))

--- a/src/test/java/capstone/examlab/token/TokenServicePythonTest.java
+++ b/src/test/java/capstone/examlab/token/TokenServicePythonTest.java
@@ -1,0 +1,18 @@
+package capstone.examlab.token;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("basic_test")
+class TokenServicePythonTest {
+    TokenService tokenService = new TokenServicePython();
+
+    @Test
+    void getTokenCount() {
+        String content = "Hello, World!";
+        int tokenCount = tokenService.getTokenCount(content);
+        assertEquals(4, tokenCount);
+    }
+}


### PR DESCRIPTION
## 변경사항
- TokenService 생성

## 배경
- AI가 인식 가능한 토큰 개수가 정해져 있어, 입력 토큰을 제한할 필요가 있었습니다.

## 테스트 방법
- src/test/java/capstone/examlab/token/TokenServicePythonTest.java
- 토큰 서비스가 잘 동작하는지 테스트하는 코드가 있습니다.

## 궁금한점
- 현재는 openai에서 제공하는 파이선 라이브러리가 유일한 토큰개수 세는 방법이라 파이선 스크립트를 실행하는 방식으로 해결했습니다.
- 추후 자바만으로 해결 가능 할 수 있어 인터페이스를 정의해 두었습니다.

close #148 