### PR TITLE
[BE] Refactoring: 태그와 속성 값 띄어쓰기 가능하도록 변경

### DIFF
--- a/src/main/java/capstone/examlab/exams/controller/ExamsController.java
+++ b/src/main/java/capstone/examlab/exams/controller/ExamsController.java
@@ -61,10 +61,15 @@ public class ExamsController {
             @Login User user,
             @Validated @RequestBody ExamAddDto examAddDto) throws BadRequestException {
 
+        for (String key : examAddDto.getTags().keySet()) {
+            if (!Util.matchesTagsValuePattern(key))
+                throw new BadRequestException("태그 명을 다시 입력해 주세요.");
+        }
+
         for (List<String> tags : examAddDto.getTags().values()) {
             for (String tag : tags) {
-                if (!Util.isSingleToken(tag))
-                    throw new BadRequestException("태그는 공백 없이 한 단어로 입력해주세요.");
+                if (!Util.matchesTagsValuePattern(tag))
+                    throw new BadRequestException("태그 값을 다시 입력해 주세요.");
             }
         }
 
@@ -96,10 +101,15 @@ public class ExamsController {
             @PathVariable @ValidExamId Long examId,
             @Validated @RequestBody ExamUpdateDto examUpdateDto) throws BadRequestException {
 
+        for(String key : examUpdateDto.getTags().keySet()) {
+            if (!Util.matchesTagsValuePattern(key))
+                throw new BadRequestException("태그 명을 다시 입력해 주세요.");
+        }
+
         for (List<String> tags : examUpdateDto.getTags().values()) {
             for (String tag : tags) {
-                if (!Util.isSingleToken(tag))
-                    throw new BadRequestException("태그는 공백 없이 한 단어로 입력해주세요.");
+                if (!Util.matchesTagsValuePattern(tag))
+                    throw new BadRequestException("태그 값을 다시 입력해 주세요.");
             }
         }
 

--- a/src/main/java/capstone/examlab/util/Util.java
+++ b/src/main/java/capstone/examlab/util/Util.java
@@ -9,6 +9,10 @@ public final class Util {
     }
 
     public static boolean matchesTagsPattern(String str) {
-        return str.matches("^tags_[a-zA-Z가-힣0-9]+$");
+        return str.matches("^tags_([a-zA-Z가-힣0-9]+(?:\\s+[a-zA-Z가-힣0-9]+)*)$");
+    }
+
+    public static boolean matchesTagsValuePattern(String str) {
+        return str.matches("^[a-zA-Z가-힣0-9]+(?:\\s+[a-zA-Z가-힣0-9]+)*");
     }
 }

--- a/src/main/java/capstone/examlab/valid/ParmasValidator.java
+++ b/src/main/java/capstone/examlab/valid/ParmasValidator.java
@@ -32,16 +32,19 @@ public class ParmasValidator implements ConstraintValidator<ValidParams, MultiVa
             }
             //value 검증
             for (String s: params.get(key)) {
-                if(key.equals("count")&&Integer.parseInt(s)>10000){
+                if(s.length() > MAX_SEARCH_PARAMETER_SIZE){
                     return false;
-                } else if(key.equals("includes")||s.length() > MAX_SEARCH_PARAMETER_SIZE){
+                }
+                else if(key.equals("count")&&Integer.parseInt(s)>10000){
+                    return false;
+                } else if(key.equals("includes")){
                     String[] words = s.split(" ");
                     for (String word : words) {
-                        if (!Util.isSingleToken(word) || word.length() > MAX_SEARCH_PARAMETER_SIZE) {
+                        if (!Util.isSingleToken(word)) {
                             return false;
                         }
                     }
-                } else if (!Util.isSingleToken(s)||s.length() > MAX_SEARCH_PARAMETER_SIZE) {
+                } else if(key.contains("tags")&&!Util.matchesTagsValuePattern(s)) {
                     return false;
                 }
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,8 +7,8 @@ spring.config.import=optional:file:src/main/resources/application-secrets.proper
 #spring.config.import=optional:file:./application-secrets.properties
 
 
-spring.profiles.active=jpa
-#spring.profiles.active=mongo
+#spring.profiles.active=jpa
+spring.profiles.active=mongo
 
 spring.s3.profile.active=test_images/
 #spring.s3.profile.active=driver_images/


### PR DESCRIPTION
## 변경사항
- 문제 검색시 태그와 속성 값 띄어쓰기 가능하도록 변경했습니다

## 배경
- 검색어와 다르게 태그는 색인된 단어를 찾는 형식이 아니다 보니 띄어쓰기 가능하다는 판단하에 내용 변경했습니다

## 테스트 방법
- 현재 DB default값이 mongoDB로 되어있어 테스트시에 JPA로 변경 및 테스트 진행해야합니다

## 궁금한점
- 없습니다 

close #164